### PR TITLE
change .once to .on

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -460,7 +460,7 @@ exports.request = function (url, args, callback) {
   });
 
   if (writeStream) {
-    writeStream.on('error', function (err) {
+    writeStream.once('error', function (err) {
       __err = err;
       debug('Request#%d %s `writeStream error` event emit, %s: %s', reqId, options.path, err.name, err.message);
       abortRequest();
@@ -469,7 +469,7 @@ exports.request = function (url, args, callback) {
 
   if (args.stream) {
     args.stream.pipe(req);
-    args.stream.on('error', function (err) {
+    args.stream.once('error', function (err) {
       __err = err;
       debug('Request#%d %s `readStream error` event emit, %s: %s', reqId, options.path, err.name, err.message);
       abortRequest();


### PR DESCRIPTION
说来非常话长的一个改动，我用各种方式想要复现某个关于 req.once('error') 的  bug 都没成功。

简单说来是我用 qn 模块的时候遇到了很奇怪的 bug，一路从 urllib 钻到 node 源码的 lib/http.js 里面去了，但仍然没法复现那个 bug，也无法理解它的出现。

大概的原因就是因为 req.once('error') 在第一次触发时被移除了监听事件，导致 socket hang up 错误，从而直接把进程搞挂。
