### PR TITLE
use pond for stream collecting

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -26,6 +26,7 @@ var typer = require('media-typer');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var ms = require('humanize-ms');
+var pond = require('pond');
 
 var _Promise;
 var _iconv;
@@ -458,45 +459,27 @@ exports.requestWithCallback = function (url, args, callback) {
     }
 
     // Otherwise, just concat those buffers.
-    //
-    // NOTE that the `chunk` is not a String but a Buffer. It means that if
-    // you simply concat two chunk with `+` you're actually converting both
-    // Buffers into Strings before concating them. It'll cause problems when
-    // dealing with multi-byte characters.
-    //
-    // The solution is to store each chunk in an array and concat them with
-    // 'buffer-concat' when all chunks is recieved.
-    //
-    // See also:
-    // http://cnodejs.org/topic/4faf65852e8fb5bc65113403
-
-    var chunks = [];
-
-    res.on('data', function (chunk) {
-      debug('Request#%d %s: `res data` event emit, size %d', reqId, url, chunk.length);
-      responseSize += chunk.length;
-      chunks.push(chunk);
-    });
-
     res.on('close', function () {
-      debug('Request#%d %s: `res close` event emit, total size %d',
-        reqId, url, responseSize);
+      debug('Request#%d %s: `res close` event emit', reqId, url);
     });
 
     res.on('error', function () {
-      debug('Request#%d %s: `res error` event emit, total size %d',
-        reqId, url, responseSize);
+      debug('Request#%d %s: `res error` event emit', reqId, url);
     });
 
     res.on('aborted', function () {
       responseAborted = true;
-      debug('Request#%d %s: `res aborted` event emit, total size %d',
-        reqId, url, responseSize);
+      debug('Request#%d %s: `res aborted` event emit', reqId, url);
     });
 
-    res.on('end', function () {
-      var body = Buffer.concat(chunks, responseSize);
-      debug('Request#%d %s: `res end` event emit, total size %d, _dumped: %s',
+    pond(res, function (err, body) {
+      if (err) {
+        return done(err);
+      }
+
+      responseSize = body.length;
+
+      debug('Request#%d %s: spooned, total size %d, _dumped: %s',
         reqId, url, responseSize, res._dumped);
 
       if (__err && connnected) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "humanize-ms": "~1.0.0",
     "iconv-lite": "~0.4.4",
     "media-typer": "~0.3.0",
-    "native-or-bluebird": "~1.1.2"
+    "native-or-bluebird": "~1.1.2",
+    "pond": "~0.1.1"
   },
   "devDependencies": {
     "agentkeepalive": "~1.2.0",


### PR DESCRIPTION
把 `res.on('data')` 和 `res.on('end')` 的部分封装起来了。

大概去年就写了 [pond](https://github.com/xingrz/pond) 这个模块打算给 urllib 用的，用的是 Node 0.10 的 WritableStream 接口，但是那时候 urllib 还要兼容 Node 0.8 所以就暂时没管了…
