### PR TITLE
Explicitly set request protocol

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -218,6 +218,7 @@ exports.requestWithCallback = function (url, args, callback) {
   }
 
   var options = {
+    protocol: parsedUrl.protocol || 'http:',
     host: parsedUrl.hostname || parsedUrl.host || 'localhost',
     path: parsedUrl.path || '/',
     method: method,


### PR DESCRIPTION
When used in browser, it may report error about not setting the protocol:

```
TypeError: Failed to execute 'fetch' on 'Window': Failed to parse URL from //http:80//10.101.168.94:6000
```

This PR fixes this issue.