### PR TITLE
fix: check url before request

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -16,6 +16,7 @@ var debug = require('debug')('urllib');
 var http = require('http');
 var https = require('https');
 var urlutil = require('url');
+var util = require('util');
 var qs = require('querystring');
 var zlib = require('zlib');
 var ua = require('default-user-agent');
@@ -173,6 +174,11 @@ exports.requestThunk = function (url, args) {
 
 exports.requestWithCallback = function (url, args, callback) {
   // requestWithCallback(url, callback)
+  if (!url || (typeof url !== 'string' && typeof url !== 'object')) {
+    var msg = util.format('expect request url to be a string or a http request options, but got %j', url);
+    throw new Error(msg);
+  }
+
   if (arguments.length === 2 && typeof args === 'function') {
     callback = args;
     args = null;

--- a/test/urllib.test.js
+++ b/test/urllib.test.js
@@ -78,6 +78,18 @@ describe('test/urllib.test.js', function () {
       });
     });
 
+    it('should request(undefined) thrown', function() {
+      (function () {
+        urllib.requestWithCallback(undefined, function() {});
+      }).should.throw('expect request url to be a string or a http request options, but got undefined');
+    });
+
+    it('should request(1) thrown', function() {
+      (function () {
+        urllib.requestWithCallback(1, function() {});
+      }).should.throw('expect request url to be a string or a http request options, but got 1');
+    });
+
     it('should request(localhost:port) work', function(done) {
       urllib.requestWithCallback('localhost:' + port, function(err, data, res) {
         should.not.exist(err);


### PR DESCRIPTION
否则后面会报错，让人没有头绪

```
> urllib.request(undefined, function(){})
TypeError: Cannot read property 'method' of undefined
    at Object.exports.requestWithCallback (/Users/deadhorse/git/urllib/lib/urllib.js:213:54)
    at Object.exports.request (/Users/deadhorse/git/urllib/lib/urllib.js:128:20)
    at repl:1:8
    at REPLServer.defaultEval (repl.js:262:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:431:12)
    at emitOne (events.js:82:20)
    at REPLServer.emit (events.js:169:7)
    at REPLServer.Interface._onLine (readline.js:211:10)
```