### PR TITLE
add environment detection for connect timer

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -727,8 +727,12 @@ exports.requestWithCallback = function requestWithCallback(url, args, callback) 
   } catch (err) {
     return done(err);
   }
-  // start connect timer just after `request` return
-  startConnectTimer();
+
+  // environment detection: browser or nodejs
+  if (typeof(window) === 'undefined') {
+    // start connect timer just after `request` return, and just in nodejs environment
+    startConnectTimer();
+  }
 
   function abortRequest() {
     debug('Request#%d %s abort, connected: %s', reqId, url, connected);


### PR DESCRIPTION
为connect timer追加一个环境判断，只在nodejs环境下开启，在browser环境下不开启。
原因：browser环境中没有socket event，会导致100% timeout warning，当使用request上传内容时，request的内存timer期间(60s)会被hold住，如果上传内容比较大，会导致内存爆掉。