### PR TITLE
fix: keep the same req object across request and response event

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -187,13 +187,14 @@ exports.requestWithCallback = function requestWithCallback(url, args, callback) 
 
   args.requestUrls = args.requestUrls || [];
 
+  var reqMeta = {
+    requestId: reqId,
+    url: url,
+    args: args,
+    ctx: args.ctx,
+  };
   if (args.emitter) {
-    args.emitter.emit('request', {
-      requestId: reqId,
-      url: url,
-      args: args,
-      ctx: args.ctx,
-    });
+    args.emitter.emit('request', reqMeta);
   }
 
   args.timeout = args.timeout || exports.TIMEOUTS;
@@ -440,17 +441,18 @@ exports.requestWithCallback = function requestWithCallback(url, args, callback) 
     cb(err, data, args.streaming ? res : response);
 
     if (args.emitter) {
+      // keep to use the same reqMeta object on request event before
+      reqMeta.url = url;
+      reqMeta.socket = req && req.connection;
+      reqMeta.options = options;
+      reqMeta.size = requestSize;
+
       args.emitter.emit('response', {
         requestId: reqId,
         error: err,
         ctx: args.ctx,
-        req: {
-          url: url,
-          socket: req && req.connection,
-          options: options,
-          size: requestSize,
-        },
-        res: response
+        req: reqMeta,
+        res: response,
       });
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "autod": "autod -w --prefix '^' -t test -e examples"
   },
   "dependencies": {
-    "any-promise": "^1.2.0",
+    "any-promise": "^1.3.0",
     "content-type": "^1.0.2",
-    "debug": "^2.2.0",
+    "debug": "^2.6.0",
     "default-user-agent": "^1.0.0",
     "digest-header": "^0.0.1",
     "humanize-ms": "^1.2.0",
-    "iconv-lite": "^0.4.13",
-    "statuses": "^1.3.0"
+    "iconv-lite": "^0.4.15",
+    "statuses": "^1.3.1"
   },
   "devDependencies": {
     "agentkeepalive": "2",
@@ -44,19 +44,19 @@
     "bluebird": "*",
     "co": "*",
     "coffee": "1",
-    "formstream": "1",
+    "formstream": "^1.1.0",
     "intelli-espower-loader": "^1.0.1",
     "istanbul": "*",
     "jshint": "*",
     "mocha": "*",
     "muk": "^0.4.0",
-    "pedding": "1",
-    "power-assert": "^1.4.1",
+    "pedding": "^1.1.0",
+    "power-assert": "^1.4.2",
     "semver": "5",
     "should": "8",
     "should-http": "*",
-    "tar": "2",
-    "through2": "2"
+    "tar": "^2.2.1",
+    "through2": "^2.0.3"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
https://github.com/eggjs/egg/issues/235