### PR TITLE
Changed to "new (require('proxy-agent'))(proxy)"

### DIFF
--- a/lib/detect_proxy_agent.js
+++ b/lib/detect_proxy_agent.js
@@ -21,7 +21,7 @@ function detectProxyAgent(uri, args) {
   if (!proxyAgent) {
     debug('create new proxy %s', proxy);
     // lazy require, only support node >= 4
-    proxyAgent = proxyAgents[proxy] = new require('proxy-agent')(proxy);
+    proxyAgent = proxyAgents[proxy] = new (require('proxy-agent'))(proxy);
   }
   debug('get proxy: %s', proxy);
   return proxyAgent;


### PR DESCRIPTION
#268

The old line
```
new require('proxy-agent')(proxy);
```
doesn't compile correctly in webpack. This change fixes that issue.