### PR TITLE
#294 Allow omitting headers by explicitly setting them as null

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -286,7 +286,9 @@ function requestWithCallback(url, args, callback) {
   };
   if (args.headers) {
     for (var k in args.headers) {
-      options.headers[k] = args.headers[k];
+      if (args.headers[k] !== null) {
+        options.headers[k] = args.headers[k];
+      }
     }
   }
 
@@ -569,7 +571,7 @@ function requestWithCallback(url, args, callback) {
   }
 
   // set user-agent
-  if (options.headers['User-Agent'] !== null && options.headers['user-agent'] !== null) {
+  if (args.headers['User-Agent'] !== null && args.headers['user-agent'] !== null) {
     var userAgentHeader = options.headers['User-Agent'] || options.headers['user-agent'];
     if (!userAgentHeader) {
       options.headers['User-Agent'] = USER_AGENT;

--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -569,8 +569,14 @@ function requestWithCallback(url, args, callback) {
   }
 
   // set user-agent
-  if (!options.headers['User-Agent'] && !options.headers['user-agent']) {
-    options.headers['User-Agent'] = USER_AGENT;
+  if (options.headers['User-Agent'] !== null && options.headers['User-Agent'] !== null) {
+    var userAgentHeader = options.headers['User-Agent'] || options.headers['user-agent'];
+    if (!userAgentHeader) {
+      options.headers['User-Agent'] = USER_AGENT;
+    }
+  } else {
+    delete options.headers['user-agent'];
+    delete options.headers['User-Agent'];
   }
 
   if (args.gzip) {

--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -571,14 +571,14 @@ function requestWithCallback(url, args, callback) {
   }
 
   // set user-agent
-  if (args.headers['User-Agent'] !== null && args.headers['user-agent'] !== null) {
+  if (args.headers && (args.headers['User-Agent'] === null || args.headers['user-agent'] === null)) {
+    delete options.headers['user-agent'];
+    delete options.headers['User-Agent'];
+  } else {
     var userAgentHeader = options.headers['User-Agent'] || options.headers['user-agent'];
     if (!userAgentHeader) {
       options.headers['User-Agent'] = USER_AGENT;
     }
-  } else {
-    delete options.headers['user-agent'];
-    delete options.headers['User-Agent'];
   }
 
   if (args.gzip) {

--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -569,7 +569,7 @@ function requestWithCallback(url, args, callback) {
   }
 
   // set user-agent
-  if (options.headers['User-Agent'] !== null && options.headers['User-Agent'] !== null) {
+  if (options.headers['User-Agent'] !== null && options.headers['user-agent'] !== null) {
     var userAgentHeader = options.headers['User-Agent'] || options.headers['user-agent'];
     if (!userAgentHeader) {
       options.headers['User-Agent'] = USER_AGENT;

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -144,6 +144,10 @@ var server = http.createServer(function (req, res) {
     } else if (req.url.indexOf('/get') === 0) {
       res.writeHeader(200);
       return res.end(req.url);
+    } else if (req.url.indexOf('/headers') === 0) {
+      res.setHeader('content-type', 'application/json');
+      res.writeHeader(200);
+      return res.end(JSON.stringify(req.headers));
     } else if (req.url === '/wrongjson') {
       res.writeHeader(200);
       return res.end(new Buffer('{"foo":""'));

--- a/test/urllib.test.js
+++ b/test/urllib.test.js
@@ -252,6 +252,21 @@ describe('test/urllib.test.js', function () {
       });
     });
 
+    it('should omit any header that is explicitly set to null', function (done) {
+      urllib.request(host + '/headers', {
+        headers: {
+          DNT: null
+        },
+        dataType: 'json'
+      }, function(err, data, res) {
+        assert(!err);
+        assert(res.statusCode === 200);
+        assert(!data.dnt);
+        assert(!data.DNT);
+        done();
+      });
+    });
+
     if (process.platform !== 'win32') {
       it('should redirect with writeStream and make sure res resume', function (done) {
         coffee.fork(path.join(__dirname, 'redirect.js'))

--- a/test/urllib.test.js
+++ b/test/urllib.test.js
@@ -1440,6 +1440,16 @@ describe('test/urllib.test.js', function () {
       });
     });
 
+    it('should return no user agent if user-agent header is set to null', function (done) {
+      urllib.request(host + '/ua', {dataType: 'json', headers: {'user-agent': null}}, function (err, data, res) {
+        console.log('data = ', data);
+        assert(!err);
+        assert(!data['user-agent']);
+        assert(res.statusCode === 200);
+        done();
+      });
+    });
+
     it('should return mock user agent', function (done) {
       urllib.request(host + '/ua', {dataType: 'json', headers: {'user-agent': 'mock agent'}},
       function (err, data, res) {


### PR DESCRIPTION
This PR allows omitting headers from a request when they're explicitly set to `null`. This helps in specific cases like Crawlera's [`X-Crawlera-Profile`](https://doc.scrapinghub.com/crawlera.html#x-crawlera-profile) header that asks to avoid sending standard headers (like `User-Agent`).

This should fix #294.