### PR TITLE
Omit the 'Accept-Encoding' header if it is explicitly set to null

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -598,8 +598,12 @@ function requestWithCallback(url, args, callback) {
   }
 
   if (args.gzip) {
-    if (!options.headers['Accept-Encoding'] && !options.headers['accept-encoding']) {
-      options.headers['Accept-Encoding'] = 'gzip, deflate';
+    var isAcceptEncodingNull = (args.headers && (args.headers['Accept-Encoding'] === null || args.headers['accept-encoding'] === null));
+    if (!isAcceptEncodingNull) {
+      var hasAcceptEncodingHeader = options.headers['Accept-Encoding'] || options.headers['accept-encoding'];
+      if (!hasAcceptEncodingHeader) {
+        options.headers['Accept-Encoding'] = 'gzip, deflate';
+      }
     }
   }
 

--- a/test/urllib.test.js
+++ b/test/urllib.test.js
@@ -267,6 +267,22 @@ describe('test/urllib.test.js', function () {
       });
     });
 
+    it('should omit accept-encoding header that is explicitly set to null even if option gzip is set to true', function (done) {
+      urllib.request(host + '/headers', {
+        headers: {
+          'Accept-Encoding': null
+        },
+        gzip: true,
+        dataType: 'json'
+      }, function(err, data, res) {
+        assert(!err);
+        assert(res.statusCode === 200);
+        assert(!data['accept-encoding']);
+        assert(!data['Accept-Encoding']);
+        done();
+      });
+    });
+
     if (process.platform !== 'win32') {
       it('should redirect with writeStream and make sure res resume', function (done) {
         coffee.fork(path.join(__dirname, 'redirect.js'))


### PR DESCRIPTION
…even if `options.gzip` is set to `true`.

@fengmk2 This follows https://github.com/node-modules/urllib/pull/295.