### PR TITLE
Expose status message from original Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Response is normal object, it contains:
 * `status` or `statusCode`: response status code.
   * `-1` meaning some network error like `ENOTFOUND`
   * `-2` meaning ConnectionTimeoutError
+* `statusMessage`: response status message.
 * `headers`: response http headers, default is `{}`
 * `size`: response size
 * `aborted`: response was aborted or not

--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -385,6 +385,7 @@ function requestWithCallback(url, args, callback) {
   var socketHandledResponses = 0; // socket already handled response count
   var responseSize = 0;
   var statusCode = -1;
+  var statusMessage = null;
   var responseAborted = false;
   var remoteAddress = '';
   var remotePort = '';
@@ -435,6 +436,7 @@ function requestWithCallback(url, args, callback) {
     var headers = {};
     if (res) {
       statusCode = res.statusCode;
+      statusMessage = res.statusMessage;
       headers = res.headers;
     }
 
@@ -466,6 +468,7 @@ function requestWithCallback(url, args, callback) {
     var response = {
       status: statusCode,
       statusCode: statusCode,
+      statusMessage: statusMessage,
       headers: headers,
       size: responseSize,
       aborted: responseAborted,

--- a/test/urllib.test.js
+++ b/test/urllib.test.js
@@ -61,6 +61,7 @@ describe('test/urllib.test.js', function () {
       assert(!error);
       assert(data instanceof Buffer);
       assert(res.statusCode === 200);
+      assert(res.statusMessage === 'OK');
       done();
     });
   });
@@ -115,6 +116,7 @@ describe('test/urllib.test.js', function () {
         assert(!err);
         assert(Buffer.isBuffer(data));
         assert(res.statusCode === 200);
+        assert(res.statusMessage === 'OK');
         // don't touch headers
         assert.deepEqual(headers, {});
         done();


### PR DESCRIPTION
This PR exposes [`statusMessage`](https://nodejs.org/api/http.html#http_response_statusmessage) from the original Response object.

This helps in cases where servers can use custom status messages.