### PR TITLE
fix: cancel connect timer when done is called

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,5 @@ fishbar <zhengxinlin@gmail.com> (https://github.com/fishbar)
 coolme200 <tangyao@taobao.com> (https://github.com/coolme200)
 amunu <panyilinlove@qq.com> (https://github.com/Amunu)
 Yuwei Ba <xiaobayuwei@gmail.com> (https://github.com/ibigbug)
+Daniel Wang <danielwpz@gmail.com> (https://github.com/danielwpz)
 

--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -410,16 +410,19 @@ function requestWithCallback(url, args, callback) {
     if (connectTimer) {
       clearTimeout(connectTimer);
       connectTimer = null;
+      debug('Request#%d connect timer canceled', reqId);
     }
   }
   function cancelResponseTimer() {
     if (responseTimer) {
       clearTimeout(responseTimer);
       responseTimer = null;
+      debug('Request#%d response timer canceled', reqId);
     }
   }
 
   function done(err, data, res) {
+    cancelConnectTimer();
     cancelResponseTimer();
     if (!callback) {
       console.warn('[urllib:warn] [%s] [%s] [worker:%s] %s %s callback twice!!!',


### PR DESCRIPTION
While making a request, errors could be thrown (e.g. when doing `PUT` with a stream and that stream is broken), thus `done` will be called with that error.

However, connectTimeout was never canceled in this case, which will lead to calling `done` twice when this timer expires.

for example:

```
  urllib Request#1 PUT http://example.com/ with headers {...}, options.path: / +0ms
  urllib ConnectTimeout: 60000, ResponseTimeout: 60000 +1ms
  urllib Connect timer ticking, timeout: 60000 +3ms
  urllib Request#1 pump args.stream to req +0ms
stream breaks!
  urllib Request#1 http://example.com `req error` event emit, RequestError: stream is broken +6ms
  urllib [11ms] done, 0 bytes HTTP -1 PUT example.com /, keepAliveSocket: false, timing: null, socketHandledRequests: 0, socketHandledResponses: 0 +1ms
```
after 60s
```
  urllib ConnectTimeout: Request#1 http://example.com/ SocketAssignTimeoutError: Connect timeout for 60000ms, working sockets is full, connected: false +60s
  urllib Request#1 http://example.com/ abort, connected: false +1ms
[urllib:warn] [Mon Mar 11 2019 12:02:40 GMT-0700 (Pacific Daylight Time)] [1] [worker:35263] PUT http://example.com/ callback twice!!!
[urllib:warn] [Mon Mar 11 2019 12:02:40 GMT-0700 (Pacific Daylight Time)] [1] [worker:35263] SocketAssignTimeoutError: Connect timeout for 60000ms, working sockets is full
```