### PR TITLE
upgrade: proxy-agent@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "humanize-ms": "^1.2.0",
     "iconv-lite": "^0.4.15",
     "ip": "^1.1.5",
-    "proxy-agent": "^2.3.1",
+    "proxy-agent": "^3.1.0",
     "pump": "^3.0.0",
     "qs": "^6.4.0",
     "statuses": "^1.3.1",


### PR DESCRIPTION
it fixes a Known Vulnerabilities:
npm WARN deprecated socks@1.1.10: If using 2.x branch, please upgrade to at least 2.1.6 to avoid a serious bug with socket data flow and an import issue introduced in 2.1.0

最新的master 在本地有一个测试失败：
```bash

  1) typescript.test.js run test:

      AssertionError [ERR_ASSERTION]: should match code expected `0(Number)` but actual `1(Number)`
      + expected - actual

      -1
      +0
      
      at node_modules/coffee/lib/assert.js:25:12
      at Array.forEach (<anonymous>)
      at module.exports (node_modules/coffee/lib/assert.js:8:12)
      at ChildProcess.<anonymous> (node_modules/coffee/lib/coffee.js:83:7)
      at maybeClose (internal/child_process.js:970:16)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
```