### PR TITLE
feat: auto set content-type header according to args.contentType

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -390,23 +390,25 @@ function requestWithCallback(url, args, callback) {
   } else {
     body = args.content || args.data;
     dataAsQueryString = method === 'GET' || method === 'HEAD' || args.dataAsQueryString;
+
+    var contentType = options.headers['Content-Type'] || options.headers['content-type'];
+    // auto add application/x-www-form-urlencoded when using urlencode form request
+    if (!contentType) {
+      if (args.contentType === 'json') {
+        contentType = 'application/json';
+      } else {
+        contentType = args.contentType || 'application/x-www-form-urlencoded';
+      }
+
+      options.headers['Content-Type'] = contentType;
+    }
+
     if (!args.content) {
       if (body && !(typeof body === 'string' || Buffer.isBuffer(body))) {
         if (dataAsQueryString) {
           // read: GET, HEAD, use query string
           body = args.nestedQuerystring ? qs.stringify(body) : querystring.stringify(body);
         } else {
-          var contentType = options.headers['Content-Type'] || options.headers['content-type'];
-          // auto add application/x-www-form-urlencoded when using urlencode form request
-          if (!contentType) {
-            if (args.contentType === 'json') {
-              contentType = 'application/json';
-            } else {
-              contentType = 'application/x-www-form-urlencoded';
-            }
-            options.headers['Content-Type'] = contentType;
-          }
-
           if (parseContentType(contentType).type === 'application/json') {
             body = JSON.stringify(body);
           } else {

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -235,6 +235,10 @@ var server = http.createServer(function (req, res) {
       return res.end(JSON.stringify({
         accept: req.headers.accept,
       }));
+    } else if (req.url === '/headers/xml') {
+      return res.end(JSON.stringify({
+        'content-type': req.headers['content-type']
+      }))
     }
 
     var url = req.url.split('?');

--- a/test/urllib.test.js
+++ b/test/urllib.test.js
@@ -524,19 +524,30 @@ describe('test/urllib.test.js', function () {
     });
 
     it('can post xml', function(done){
-      var params = {
+      var options = {
+        method: 'POST',
         content: '<xml></xml>',
         contentType: 'application/xml'
       };
-      var options = {
-        path: '/post',
-        method: 'post',
-        port: port
-      };
-      urllib.request(options, params, function(err, data, res){
+      urllib.request(host + '/post', options, function(err, data, res){
         assert(!err);
         assert(res.statusCode === 200);
         assert(data.toString() === '<xml></xml>');
+
+        done();
+      });
+    });
+
+    it('should auto set content-type header for application/xml request', function(done){
+      var options = {
+        method: 'POST',
+        content: '<xml></xml>',
+        contentType: 'application/xml'
+      };
+      urllib.request(host + '/headers/xml', options, function(err, data, res){
+        assert(!err);
+        assert(res.statusCode === 200);
+        assert(JSON.parse(data.toString())['content-type'] === 'application/xml');
 
         done();
       });


### PR DESCRIPTION
针对 #69 提出的问题，https://github.com/node-modules/urllib/issues/69#issuecomment-112091098 给出的方案：
> `content`: xml-string, and `contentType`: `'application/xml'`

其中，`contentType` 并不起作用（没有将 `application/xml` 设置到请求头中）。

虽然添加的 post xml 测试 #324 能够通过，那是因为测试中起的 test server 并没有判断 content-type，测试用例只是将 content 作为 raw string 传给了 test server。

后来发现，koa 以及 egg 这样的服务端，都不能正确接收 `{content: '<xml></xml>', contentType: 'application/xml'}` 这样的数据，因为这两个框架都用了 `koa-bodyparser`，而这个 parser 会根据 request header 中的 content-type 来做解析。

所以，当 contentType 设置为 application/xml 时，有必须自动添加 content-type 到请求头中（这个 PR 中已添加测试用例来反映这个情况）。
