### PR TITLE
fix: add  field to typescript declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 coverage/
 test/.tmp*
 examples/request_over_proxy_tmp.js
+.idea

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ httpclient.request('http://nodejs.org', function (err, body) {
     - ***content*** String | [Buffer](http://nodejs.org/api/buffer.html) - Manually set the content of payload. If set, `data` will be ignored.
     - ***stream*** [stream.Readable](http://nodejs.org/api/stream.html#stream_class_stream_readable) - Stream to be pipe to the remote. If set, `data` and `content` will be ignored.
     - ***writeStream*** [stream.Writable](http://nodejs.org/api/stream.html#stream_class_stream_writable) - A writable stream to be piped by the response stream. Responding data will be write to this stream and `callback` will be called with `data` set `null` after finished writing.
-    - ***files*** {Array<ReadStream|Buffer|String> | Object | ReadStream | Buffer | String - The files will send with `multipart/form-data` format, base on `formstream`. If `method` not set, will use `POST` method by default.
+    - ***files*** {Array<ReadStream|Buffer|String>} | Object | ReadStream | Buffer | String - The files will send with `multipart/form-data` format, base on `formstream`. If `method` not set, will use `POST` method by default.
     - ***consumeWriteStream*** [true] - consume the writeStream, invoke the callback after writeStream close.
     - ***contentType*** String - Type of request data. Could be `json`. If it's `json`, will auto set `Content-Type: application/json` header.
     - ***nestedQuerystring*** Boolean - urllib default use querystring to stringify form data which don't support nested object, will use [qs](https://github.com/ljharb/qs) instead of querystring to support nested object by set this option to true.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -123,6 +123,11 @@ export interface RequestOptions {
    * It rely on lookup and have the same version requirement.
    */
   checkAddress?: (ip: string, family: number | string) => boolean;
+  /**
+  * The files will send with multipart/form-data format, base on formstream.
+  * If method not set, will use POST method by default.
+  */
+  files?:  Array<Readable | Buffer | string> | {[key: string]: Readable | Buffer | string} | Readable | Buffer | string
 }
 
 export interface HttpClientResponse<T> {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -127,7 +127,7 @@ export interface RequestOptions {
   * The files will send with multipart/form-data format, base on formstream.
   * If method not set, will use POST method by default.
   */
-  files?:  Array<Readable | Buffer | string> | {[key: string]: Readable | Buffer | string} | Readable | Buffer | string
+  files?:  Array<Readable | Buffer | string | {pipe: Function}> | {[key: string]: Readable | Buffer | string | {pipe: Function}} | Readable | Buffer | string | {pipe: Function}
 }
 
 export interface HttpClientResponse<T> {

--- a/test/typescript/index.ts
+++ b/test/typescript/index.ts
@@ -111,6 +111,12 @@ describe('typescript', () => {
       assert(res.status === 200);
     });
 
+    it('request return promise with `files` options', async ()=>{
+      const res = await request(url, { files: Buffer.from('mock file content') });
+      assert(res.data.toString() === 'done')
+      assert(res.status === 200)
+    });
+
     it('request with callback', done => {
       request<Buffer>(url, function(err, data, res) {
         assert(data.toString() === 'done');


### PR DESCRIPTION
修复一个 TypeScript 声明文件，以解决在 TypeScript 项目中上传文件无法通过 TS 编译的问题：

![image](https://user-images.githubusercontent.com/3367820/69520860-9f489080-0f98-11ea-9ff8-cfc15e1d9538.png)

才发现有个 PR: #334 也修了这个，不过这个 PR 增加了测试和修复了一个文档里的少掉的 } 。
