### PR TITLE
fix: res.socket is null in node-v14.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - '8'
   - '10'
   - '12'
+  - '14'
 script:
   - npm run ci
 after_script:

--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -196,6 +196,7 @@ exports.requestThunk = function requestThunk(url, args) {
 };
 
 function requestWithCallback(url, args, callback) {
+  var req;
   // requestWithCallback(url, callback)
   if (!url || (typeof url !== 'string' && typeof url !== 'object')) {
     var msg = util.format('expect request url to be a string or a http request options, but got %j', url);
@@ -592,10 +593,11 @@ function requestWithCallback(url, args, callback) {
           if (serverSocketTimeout < freeSocketTimeout) {
             // https://github.com/node-modules/agentkeepalive/blob/master/lib/agent.js#L127
             // agentkeepalive@4
+            var socket = res.socket || (req && req.socket);
             if (agent.options && agent.options.freeSocketTimeout) {
-              res.socket.freeSocketTimeout = serverSocketTimeout;
+              socket.freeSocketTimeout = serverSocketTimeout;
             } else {
-              res.socket.freeSocketKeepAliveTimeout = serverSocketTimeout;
+              socket.freeSocketKeepAliveTimeout = serverSocketTimeout;
             }
           }
         }
@@ -966,7 +968,6 @@ function requestWithCallback(url, args, callback) {
     }
   }
 
-  var req;
   // request headers checker will throw error
   try {
     req = httplib.request(options, onResponse);


### PR DESCRIPTION
In node-v14.x, `res.socket` has been detached from IncomingMessage.

Reference: https://github.com/nodejs/node/pull/32153
Reference: [V14 Semver-Major Commits](https://github.com/nodejs/node/blob/v14.0.0/doc/changelogs/CHANGELOG_V14.md#semver-major-commits)