### PR TITLE
fix: upgrade iconv-lite to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ee-first": "~1.1.1",
     "formstream": "^1.1.0",
     "humanize-ms": "^1.2.0",
-    "iconv-lite": "^0.4.15",
+    "iconv-lite": "^0.6.2",
     "ip": "^1.1.5",
     "proxy-agent": "^4.0.1",
     "pump": "^3.0.0",


### PR DESCRIPTION
Fix `Exception __webpack_require__(...) is not a function` in Webpack 4
https://github.com/ashtuchkin/iconv-lite/issues/204