### PR TITLE
fix: 🐛 should trigger response event when follow redirect

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -520,9 +520,6 @@ function requestWithCallback(url, args, callback) {
       }
       return;
     }
-    if (handleDigestAuth(res, callback)) {
-      return;
-    }
 
     var cb = callback;
     callback = null;
@@ -531,6 +528,10 @@ function requestWithCallback(url, args, callback) {
       statusCode = res.statusCode;
       statusMessage = res.statusMessage;
       headers = res.headers;
+    }
+
+    if (handleDigestAuth(res, cb)) {
+      return;
     }
 
     var response = createCallbackResponse(data, res);
@@ -587,12 +588,12 @@ function requestWithCallback(url, args, callback) {
 
     cb(err, data, args.streaming ? res : response);
 
-    emitResponseEvent(response);
+    emitResponseEvent(err, response);
   }
 
   function createAndEmitResponseEvent(data, res) {
     var response = createCallbackResponse(data, res);
-    emitResponseEvent(response);
+    emitResponseEvent(null, response);
   }
 
   function createCallbackResponse(data, res) {
@@ -602,7 +603,7 @@ function requestWithCallback(url, args, callback) {
     }
 
     var headers = {};
-    if (res.headers) {
+    if (res && res.headers) {
       headers = res.headers;
     }
 
@@ -625,7 +626,7 @@ function requestWithCallback(url, args, callback) {
     };
   }
 
-  function emitResponseEvent(response) {
+  function emitResponseEvent(err, response) {
     if (args.emitter) {
       // keep to use the same reqMeta object on request event before
       reqMeta.url = parsedUrl.href;
@@ -645,8 +646,8 @@ function requestWithCallback(url, args, callback) {
 
   function handleDigestAuth(res, cb) {
     var headers = {};
-    if (res) {
-      headers = res.header;
+    if (res && res.headers) {
+      headers = res.headers;
     }
     // handle digest auth
     if (statusCode === 401 && headers['www-authenticate']

--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -520,6 +520,10 @@ function requestWithCallback(url, args, callback) {
       }
       return;
     }
+    if (handleDigestAuth(res, callback)) {
+      return;
+    }
+
     var cb = callback;
     callback = null;
     var headers = {};
@@ -529,48 +533,11 @@ function requestWithCallback(url, args, callback) {
       headers = res.headers;
     }
 
-    // handle digest auth
-    if (statusCode === 401 && headers['www-authenticate']
-        && !options.headers.authorization && args.digestAuth) {
-      var authenticate = headers['www-authenticate'];
-      if (authenticate.indexOf('Digest ') >= 0) {
-        debug('Request#%d %s: got digest auth header WWW-Authenticate: %s', reqId, url, authenticate);
-        options.headers.authorization = digestAuthHeader(options.method, options.path, authenticate, args.digestAuth);
-        debug('Request#%d %s: auth with digest header: %s', reqId, url, options.headers.authorization);
-        if (res.headers['set-cookie']) {
-          options.headers.cookie = res.headers['set-cookie'].join(';');
-        }
-        args.headers = options.headers;
-        return exports.requestWithCallback(url, args, cb);
-      }
-    }
-
-    var requestUseTime = Date.now() - requestStartTime;
-    if (timing) {
-      timing.contentDownload = requestUseTime;
-    }
+    var response = createCallbackResponse(data, res);
 
     debug('[%sms] done, %s bytes HTTP %s %s %s %s, keepAliveSocket: %s, timing: %j, socketHandledRequests: %s, socketHandledResponses: %s',
-      requestUseTime, responseSize, statusCode, options.method, options.host, options.path,
+      response.requestUseTime, responseSize, statusCode, options.method, options.host, options.path,
       keepAliveSocket, timing, socketHandledRequests, socketHandledResponses);
-
-    var response = {
-      status: statusCode,
-      statusCode: statusCode,
-      statusMessage: statusMessage,
-      headers: headers,
-      size: responseSize,
-      aborted: responseAborted,
-      rt: requestUseTime,
-      keepAliveSocket: keepAliveSocket,
-      data: data,
-      requestUrls: args.requestUrls,
-      timing: timing,
-      remoteAddress: remoteAddress,
-      remotePort: remotePort,
-      socketHandledRequests: socketHandledRequests,
-      socketHandledResponses: socketHandledResponses,
-    };
 
     if (err) {
       var agentStatus = '';
@@ -620,6 +587,45 @@ function requestWithCallback(url, args, callback) {
 
     cb(err, data, args.streaming ? res : response);
 
+    emitResponseEvent(response);
+  }
+
+  function createAndEmitResponseEvent(data, res) {
+    var response = createCallbackResponse(data, res);
+    emitResponseEvent(response);
+  }
+
+  function createCallbackResponse(data, res) {
+    var requestUseTime = Date.now() - requestStartTime;
+    if (timing) {
+      timing.contentDownload = requestUseTime;
+    }
+
+    var headers = {};
+    if (res.headers) {
+      headers = res.headers;
+    }
+
+    return {
+      status: statusCode,
+      statusCode: statusCode,
+      statusMessage: statusMessage,
+      headers: headers,
+      size: responseSize,
+      aborted: responseAborted,
+      rt: requestUseTime,
+      keepAliveSocket: keepAliveSocket,
+      data: data,
+      requestUrls: args.requestUrls,
+      timing: timing,
+      remoteAddress: remoteAddress,
+      remotePort: remotePort,
+      socketHandledRequests: socketHandledRequests,
+      socketHandledResponses: socketHandledResponses,
+    };
+  }
+
+  function emitResponseEvent(response) {
     if (args.emitter) {
       // keep to use the same reqMeta object on request event before
       reqMeta.url = parsedUrl.href;
@@ -635,6 +641,30 @@ function requestWithCallback(url, args, callback) {
         res: response,
       });
     }
+  }
+
+  function handleDigestAuth(res, cb) {
+    var headers = {};
+    if (res) {
+      headers = res.header;
+    }
+    // handle digest auth
+    if (statusCode === 401 && headers['www-authenticate']
+        && !options.headers.authorization && args.digestAuth) {
+      var authenticate = headers['www-authenticate'];
+      if (authenticate.indexOf('Digest ') >= 0) {
+        debug('Request#%d %s: got digest auth header WWW-Authenticate: %s', reqId, url, authenticate);
+        options.headers.authorization = digestAuthHeader(options.method, options.path, authenticate, args.digestAuth);
+        debug('Request#%d %s: auth with digest header: %s', reqId, url, options.headers.authorization);
+        if (res.headers['set-cookie']) {
+          options.headers.cookie = res.headers['set-cookie'].join(';');
+        }
+        args.headers = options.headers;
+        exports.requestWithCallback(url, args, cb);
+        return true;
+      }
+    }
+    return false;
   }
 
   function handleRedirect(res) {
@@ -740,6 +770,7 @@ function requestWithCallback(url, args, callback) {
       var result = handleRedirect(res);
       if (result.redirect) {
         res.resume();
+        createAndEmitResponseEvent(null, res);
         return;
       }
       if (result.error) {
@@ -781,6 +812,7 @@ function requestWithCallback(url, args, callback) {
       var result = handleRedirect(res);
       if (result.redirect) {
         res.resume();
+        createAndEmitResponseEvent(null, res);
         return;
       }
       if (result.error) {
@@ -874,6 +906,7 @@ function requestWithCallback(url, args, callback) {
         return done(result.error, body, res);
       }
       if (result.redirect) {
+        createAndEmitResponseEvent(null, res);
         return;
       }
 

--- a/test/config.js
+++ b/test/config.js
@@ -5,7 +5,7 @@ module.exports = process.env.CI ? {
   npmRegistry: 'https://registry.npmjs.com',
   npmHttpRegistry: 'http://registry.npmjs.com',
 } : {
-  npmWeb: 'https://developer.aliyun.com/mirror/npm',
+  npmWeb: 'https://www.npmjs.com',
   npmRegistry: 'https://registry.npm.taobao.org',
   npmHttpRegistry: 'http://registry.npm.taobao.org',
 };

--- a/test/files.test.js
+++ b/test/files.test.js
@@ -70,7 +70,7 @@ describe('test/files.test.js', function() {
       assert(result.headers['content-type'].indexOf('multipart/form-data;') === 0);
       assert(res.status === 200);
       assert(result.files.file.filename === 'bufferfile0');
-      assert(result.files.file.mimetype === 'application/octet-stream');
+      assert(result.files.file.mimetype === 'text/plain');
       done();
     });
   });
@@ -90,7 +90,7 @@ describe('test/files.test.js', function() {
       assert(result.files.file1.filename === 'files.test.js');
       assert(result.files.file1.mimetype === 'application/javascript');
       assert(result.files.file2.filename === 'bufferfile2');
-      assert(result.files.file2.mimetype === 'application/octet-stream');
+      assert(result.files.file2.mimetype === 'text/plain');
       done();
     });
   });

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -9,7 +9,7 @@ var isNode012 = /^v0\.12\.\d+$/.test(process.version);
 var testUrl = process.env.CI ? 'https://registry.npmjs.com' : 'https://registry.npm.taobao.org';
 
 if (!isNode010 && !isNode012) {
-  describe.only('test/proxy.test.js', function() {
+  describe('test/proxy.test.js', function() {
     var port;
     var proxyUrl;
     before(function(done) {

--- a/test/urllib.test.js
+++ b/test/urllib.test.js
@@ -1704,6 +1704,33 @@ describe('test/urllib.test.js', function () {
         done();
       });
     });
+
+    it('should trigger req/res in pair when followRedirect', function (done) {
+      done = pedding(5, done);
+      var redirected = false;
+      urllib.on('request', function (info) {
+        info.args.headers = info.args.headers || {};
+        info.args.headers['custom-header'] = 'custom-header';
+        done();
+      });
+      urllib.on('response', function (info) {
+        if (info.req.options.path === '/302-to-200') {
+          redirected = true;
+        }
+        assert(info.req.options.headers['custom-header'] === 'custom-header');
+        assert(redirected);
+        done();
+      });
+
+      urllib.request(host + '/302-to-200', {
+        followRedirect: true,
+        ctx: {
+          foo: 'error request'
+        }
+      }, function () {
+        done();
+      });
+    });
   });
 
   describe('charset support', function () {

--- a/test/urllib_promise.test.js
+++ b/test/urllib_promise.test.js
@@ -38,6 +38,7 @@ describe('test/urllib_promise.test.js', function () {
       timeout: 20000
     })
     .then(function (result) {
+      console.dir(result);
       assert(result.data);
       assert(result.res);
       assert(result.data instanceof Buffer);

--- a/test/urllib_promise.test.js
+++ b/test/urllib_promise.test.js
@@ -38,7 +38,6 @@ describe('test/urllib_promise.test.js', function () {
       timeout: 20000
     })
     .then(function (result) {
-      console.dir(result);
       assert(result.data);
       assert(result.res);
       assert(result.data instanceof Buffer);


### PR DESCRIPTION
现有 followRedirect 的情况下，response 事件只会触发一次（redirect 之后的请求的 response），request 会触发两次（redirect 前请求的 resquest 和 request 之后的 response）