### PR TITLE
Avoid options modify side-effect

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -216,7 +216,7 @@ function requestWithCallback(url, args, callback) {
   }
   var reqId = ++REQUEST_ID;
 
-  args.requestUrls = args.requestUrls || [];
+  var requestUrls = JSON.parse(JSON.stringify(args.requestUrls)) || [];
 
   args.timeout = args.timeout || exports.TIMEOUTS;
   args.maxRedirects = args.maxRedirects || 10;
@@ -616,7 +616,7 @@ function requestWithCallback(url, args, callback) {
       rt: requestUseTime,
       keepAliveSocket: keepAliveSocket,
       data: data,
-      requestUrls: args.requestUrls,
+      requestUrls: requestUrls,
       timing: timing,
       remoteAddress: remoteAddress,
       remotePort: remotePort,
@@ -756,7 +756,7 @@ function requestWithCallback(url, args, callback) {
   debug('Request#%d %s %s with headers %j, options.path: %s',
     reqId, method, url, options.headers, options.path);
 
-  args.requestUrls.push(parsedUrl.href);
+  requestUrls.push(parsedUrl.href);
 
   function onResponse(res) {
     socketHandledResponses = res.socket[SOCKET_RESPONSE_COUNT] = (res.socket[SOCKET_RESPONSE_COUNT] || 0) + 1;


### PR DESCRIPTION
Each request adds to options object requested url, so options.requestUrl keeps growing over the time and increasing memory consumption. 