### PR TITLE
feat: support stream.filename

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -386,7 +386,7 @@ function requestWithCallback(url, args, callback) {
       if (Buffer.isBuffer(item[1])) {
         form.buffer(item[0], item[1], 'bufferfile' + i);
       } else if (typeof item[1].pipe === 'function') {
-        var filename = item[1].path || ('streamfile' + i);
+        var filename = item[1].filename || item[1].path || ('streamfile' + i);
         filename = path.basename(filename);
         form.stream(item[0], item[1], filename);
       } else {


### PR DESCRIPTION
feat: 支持stream的filename属性，以支持egg服务端转发文件流时可以检验文件名后缀