### PR TITLE
🐛 FIX: Alias reqMeta.options to reqMeta.args

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -489,7 +489,10 @@ export class HttpClient extends EventEmitter {
           requestId,
           error: null,
           ctx: args.ctx,
-          req: reqMeta,
+          req: {
+            ...reqMeta,
+            options: args,
+          },
           res,
         });
       }

--- a/test/HttpClient.events.test.ts
+++ b/test/HttpClient.events.test.ts
@@ -35,6 +35,7 @@ describe('HttpClient.events.test.ts', () => {
       responseCount++;
       // console.log(info);
       assert.equal(info.req.args.opaque.requestId, `mock-request-id-${requestCount}`);
+      assert.equal(info.req.options, info.req.args);
       assert.equal(info.res.status, 200);
       assert.equal(info.requestId, info.req.requestId);
 
@@ -55,6 +56,9 @@ describe('HttpClient.events.test.ts', () => {
     });
     assert.equal(response.status, 200);
     assert.equal(response.data.method, 'GET');
+    assert.equal(requestCount, 1);
+    assert.equal(responseCount, 1);
+
     response = await httpclient.request(_url, {
       dataType: 'json',
       opaque: {


### PR DESCRIPTION
Keep 'response' event compatibility