### PR TITLE
FIX: Include query parameters in digest uri

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -373,7 +373,7 @@ export class HttpClient extends EventEmitter {
         if (authenticate.startsWith('Digest ')) {
           debug('Request#%d %s: got digest auth header WWW-Authenticate: %s', requestId, requestUrl.href, authenticate);
           requestOptions.headers.authorization = digestAuthHeader(requestOptions.method!,
-            requestUrl.pathname, authenticate, args.digestAuth);
+            `${requestUrl.pathname}${requestUrl.search}`, authenticate, args.digestAuth);
           debug('Request#%d %s: auth with digest header: %s', requestId, url, requestOptions.headers.authorization);
           if (response.headers['set-cookie']) {
             // FIXME: merge exists cookie header

--- a/test/options.digestAuth.test.ts
+++ b/test/options.digestAuth.test.ts
@@ -24,6 +24,7 @@ describe('options.digestAuth.test.ts', () => {
     assert(response.data.authorization);
     // console.log(response.data);
     assert.match(response.data.authorization, /Digest username="user", realm="testrealm@urllib.com", nonce="/);
+    assert.match(response.data.authorization, /, uri="\/digestAuth",/);
   });
 
   it('should auth fail', async () => {
@@ -45,6 +46,16 @@ describe('options.digestAuth.test.ts', () => {
     assert.deepEqual(response.data, {
       error: 'authorization required',
     });
+  });
+
+  it('should digest auth with query', async () => {
+    const response = await urllib.request(`${_url}digestAuth?t=123123`, {
+      digestAuth: 'user:pwd',
+      dataType: 'json',
+    });
+    assert.equal(response.status, 200);
+    assert(response.data.authorization);
+    assert.match(response.data.authorization, /, uri="\/digestAuth\?t=123123",/);
   });
 
   it.skip('should request with digest auth success in httpbin', async () => {


### PR DESCRIPTION
Discovered that digest authentication was failing with request 3.1.2 when the URL contains query parameters:

```ts
await urllib.request(
  'http://${address}/api/v1/public?sys.info.model',
  {
    method: 'POST',
    digestAuth: `${user}:${pass}`,
  }
);
```

This fails as the uri parameter in the authorization header doesn't match the requested uri:

```
GET /api/v1/public?sys.info.model HTTP/1.1
...
authorization: Digest username="test", realm="M8 Processor", nonce="eH2KYs4TQ5RG6kGR2VWAhLvSX6l0Vthg", uri="/api/v1/public", response="fbf377fb93eb5a5b4455a298eb68a439", opaque="0e8ccb02b0ae1507f8237e97540fedb1", qop=auth, nc=00000002, cnonce="6e4ca7a668f60e18"

HTTP/1.1 401 Unauthorized
```
(note the lack of query in uri="/api/v1/public")

Per section 2.1.2 in RFC2069:
```
digest-uri          = "uri" "=" digest-uri-value
digest-uri-value    = request-uri         ; As specified by HTTP/1.1
```

and section 3.2.1 in RFC2068:
```
URI            = ( absoluteURI | relativeURI ) [ "#" fragment ]

absoluteURI    = scheme ":" *( uchar | reserved )

relativeURI    = net_path | abs_path | rel_path

net_path       = "//" net_loc [ abs_path ]
abs_path       = "/" rel_path
rel_path       = [ path ] [ ";" params ] [ "?" query ]
```

query is considered part of the URI

Specifically Passport.js digest strategy checks that the uri matches. And also confirmed this same request with Postman which did include the query parameters and successfully authenticated.

As such here's a PR which appends the query parameters, along with an additional test case to make sure they made it through.

Thanks for your great lib!
