### PR TITLE
fix: autocomplete non-protocol links

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/busboy": "^1.5.0",
     "@types/default-user-agent": "^1.0.0",
     "@types/mime-types": "^2.1.1",
+    "@types/node": "^18.7.23",
     "@types/pump": "^1.1.1",
     "@types/selfsigned": "^2.0.1",
     "@vitest/coverage-c8": "^0.23.4",

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -153,7 +153,12 @@ export class HttpClient extends EventEmitter {
 
   async #requestInternal(url: RequestURL, options?: RequestOptions, requestContext?: RequestContext): Promise<HttpClientResponse> {
     const requestId = globalId('HttpClientRequest');
-    const requestUrl = typeof url === 'string' ? new URL(url) : url;
+    let requestUrl: URL;
+    if (typeof url === 'string') {
+      requestUrl = new URL(/^https?:\/\//i.test(url) ? url : `http://${url}`);
+    } else {
+      requestUrl = url;
+    }
     const args = {
       retry: 0,
       ...this.#defaultArgs,
@@ -395,7 +400,7 @@ export class HttpClient extends EventEmitter {
       let response = await undiciRequest(requestUrl, requestOptions);
       // handle digest auth
       if (response.statusCode === 401 && response.headers['www-authenticate'] &&
-          !requestOptions.headers.authorization && args.digestAuth) {
+        !requestOptions.headers.authorization && args.digestAuth) {
         const authenticate = response.headers['www-authenticate'];
         if (authenticate.startsWith('Digest ')) {
           debug('Request#%d %s: got digest auth header WWW-Authenticate: %s', requestId, requestUrl.href, authenticate);

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -74,6 +74,23 @@ describe('HttpClient.test.ts', () => {
       }
       assert(lookupCallCounter < 5, `${lookupCallCounter} should smaller than 5`);
     });
+
+    it('should work with custom lookup on none-protol links', async () => {
+      let lookupCallCounter = 0;
+      const httpclient = new HttpClient({
+        // mock lookup delay
+        lookup(...args) {
+          lookupCallCounter++;
+          setTimeout(() => {
+            dns.lookup(...args);
+          }, 100);
+        },
+      });
+      let response = await httpclient.request('registry.npmmirror.com/urllib');
+      // default http => https
+      assert.equal(lookupCallCounter, 2);
+      assert.equal(response.status, 200);
+    });
   });
 
   describe('clientOptions.checkAddress', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "esModuleInterop": true,
     "stripInternal": true,
     "lib": [
-      "ESNext"
+      "ESNext",
+      "dom",
     ],
     "composite": true,
     "types": [


### PR DESCRIPTION
* autocomplete  non-protocol links such as: `mock.urllib.com`
* fix type error