### PR TITLE
🐛 FIX: Keep req.options on error response event

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -556,7 +556,10 @@ export class HttpClient extends EventEmitter {
           requestId,
           error: err,
           ctx: args.ctx,
-          req: reqMeta,
+          req: {
+            ...reqMeta,
+            options: args,
+          },
           res,
         });
       }

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -164,10 +164,17 @@ export class HttpClient extends EventEmitter {
     } else {
       requestUrl = url;
     }
+
+    const method = (options?.method ?? 'GET').toUpperCase() as HttpMethod;
+    const orginalHeaders = options?.headers;
+    const headers: IncomingHttpHeaders = {};
     const args = {
       retry: 0,
       ...this.#defaultArgs,
       ...options,
+      // keep method and headers exists on args for request event handler to easy use
+      method,
+      headers,
     };
     requestContext = {
       retries: 0,
@@ -245,13 +252,10 @@ export class HttpClient extends EventEmitter {
         headersTimeout = bodyTimeout = args.timeout;
       }
     }
-
-    const method = (args.method ?? 'GET').toUpperCase() as HttpMethod;
-    const headers: IncomingHttpHeaders = {};
-    if (args.headers) {
+    if (orginalHeaders) {
       // convert headers to lower-case
-      for (const name in args.headers) {
-        headers[name.toLowerCase()] = args.headers[name];
+      for (const name in orginalHeaders) {
+        headers[name.toLowerCase()] = orginalHeaders[name];
       }
     }
     // hidden user-agent

--- a/test/HttpClient.events.test.ts
+++ b/test/HttpClient.events.test.ts
@@ -38,6 +38,8 @@ describe('HttpClient.events.test.ts', () => {
       // console.log(info);
       assert.equal(info.req.args.opaque.requestId, `mock-request-id-${requestCount}`);
       assert.equal(info.req.options, info.req.args);
+      assert(info.req.args.headers);
+      assert(info.req.options.headers);
       assert.equal(info.res.status, 200);
       assert.equal(info.requestId, info.req.requestId);
 
@@ -97,6 +99,8 @@ describe('HttpClient.events.test.ts', () => {
       // console.log(info);
       assert.equal(info.req.args.opaque.requestId, `mock-request-id-${requestCount}`);
       assert.equal(info.req.options, info.req.args);
+      assert(info.req.args.headers);
+      assert(info.req.options.headers);
       assert.equal(info.res.status, -1);
       assert.equal(info.requestId, info.req.requestId);
 

--- a/test/HttpClient.events.test.ts
+++ b/test/HttpClient.events.test.ts
@@ -84,4 +84,41 @@ describe('HttpClient.events.test.ts', () => {
     assert.equal(requestCount, 2);
     assert.equal(responseCount, 2);
   });
+
+  it('should emit response on request error', async () => {
+    const httpclient = new HttpClient();
+    let requestCount = 0;
+    let responseCount = 0;
+    httpclient.on('request', info => {
+      requestCount++;
+    });
+    httpclient.on('response', info => {
+      responseCount++;
+      // console.log(info);
+      assert.equal(info.req.args.opaque.requestId, `mock-request-id-${requestCount}`);
+      assert.equal(info.req.options, info.req.args);
+      assert.equal(info.res.status, -1);
+      assert.equal(info.requestId, info.req.requestId);
+
+      assert.equal(info.error.name, 'SocketError');
+      assert.equal(info.error.message, 'other side closed');
+      assert.equal(info.error.status, -1);
+    });
+
+    await assert.rejects(async () => {
+      await httpclient.request(`${_url}error`, {
+        dataType: 'json',
+        opaque: {
+          requestId: 'mock-request-id-1',
+        },
+        ctx: { foo: 'bar' },
+      });
+    }, (err: any) => {
+      // console.error(err);
+      assert.equal(err.name, 'SocketError');
+      assert.equal(err.message, 'other side closed');
+      assert.equal(err.status, -1);
+      return true;
+    });
+  });
 });


### PR DESCRIPTION
Keep 'response' event compatibility

see https://github.com/node-modules/urllib/pull/391