### PR TITLE
fix: Don't mutate passed URL object

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -197,9 +197,13 @@ export class HttpClient extends EventEmitter {
       }
       requestUrl = new URL(url);
     } else {
-      // url maybe url.parse(url) object in urllib2
-      // or even if not, we clone to avoid mutating it
-      requestUrl = new URL(urlFormat(url));
+      if (!url.searchParams) {
+        // url maybe url.parse(url) object in urllib2
+        requestUrl = new URL(urlFormat(url));
+      } else {
+        // or even if not, we clone to avoid mutating it
+        requestUrl = new URL(url.toString());
+      }
     }
 
     const method = (options?.method ?? 'GET').toUpperCase() as HttpMethod;

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -201,7 +201,8 @@ export class HttpClient extends EventEmitter {
         // url maybe url.parse(url) object in urllib2
         requestUrl = new URL(urlFormat(url));
       } else {
-        requestUrl = url;
+        // Don't mutate the URL object the user passed in
+        requestUrl = new URL(url);
       }
     }
 

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -197,13 +197,9 @@ export class HttpClient extends EventEmitter {
       }
       requestUrl = new URL(url);
     } else {
-      if (!url.searchParams) {
-        // url maybe url.parse(url) object in urllib2
-        requestUrl = new URL(urlFormat(url));
-      } else {
-        // Don't mutate the URL object the user passed in
-        requestUrl = new URL(url);
-      }
+      // url maybe url.parse(url) object in urllib2
+      // or even if not, we clone to avoid mutating it
+      requestUrl = new URL(urlFormat(url));
     }
 
     const method = (options?.method ?? 'GET').toUpperCase() as HttpMethod;

--- a/test/options.data.test.ts
+++ b/test/options.data.test.ts
@@ -43,6 +43,15 @@ describe('options.data.test.ts', () => {
     assert.equal(url.searchParams.get('data'), '哈哈');
   });
 
+  it('should not mutate a passed URL object when setting query string', async () => {
+    const url = new URL(_url);
+    assert.equal(url.searchParams.get('param1'), null);
+    await urllib.request(url, {
+      data: { param1: 'val1' },
+    });
+    assert.equal(url.searchParams.get('param1'), null);
+  });
+
   it('should GET with data work on nestedQuerystring=true', async () => {
     const response = await urllib.request(_url, {
       method: 'GET',


### PR DESCRIPTION
Before this change, a passed URL object would be mutated if query parameters were appended via the `data` option.

Now we clone the object instead, so the original is not affected.

---

Background:

I am passing `URL` objects to the `request` method, and then adding query parameters via the `data` option. Example:

```js
import { request } from "urllib";

const url = new URL("http://example.com");

await request(url, { data: { param1: "value1" } });
```

I found that if I then make another request to the same URL but with different parameters:

```js
await request(url, { data: { param2: "value2" } });
```

...a request is actually made to `http://example.com?param1=value1&param2=value2`.

My URL object is being mutated by the urllib library. I see this as a bug.