### PR TITLE
feat: support custom filename when 

### DIFF
--- a/test/options.files.test.ts
+++ b/test/options.files.test.ts
@@ -120,7 +120,7 @@ describe('options.files.test.ts', () => {
     // console.log(response.data);
     assert.equal(response.data.method, 'POST');
     assert.match(response.data.headers['content-type'], /^multipart\/form-data;/);
-    assert.equal(response.data.files.hello.filename, 'bufferfile0');
+    assert.equal(response.data.files.hello.filename, 'hello');
     assert.equal(response.data.files.hello.mimeType, 'application/octet-stream');
     assert.equal(response.data.files.hello.encoding, '7bit');
     assert.equal(response.data.files.hello.size, 11);
@@ -265,6 +265,36 @@ describe('options.files.test.ts', () => {
     assert.equal(response.data.files.foo.filename, 'options.files.test.ts');
     assert.equal(response.data.files.foo.mimeType, 'video/mp2t');
     assert.equal(response.data.files.foo.size, stat.size);
+    assert.equal(response.data.form.hello, 'hello world，😄😓');
+    assert.equal(response.data.form.foo, 'bar');
+  });
+
+  it('should support custom fileName when use files:object', async () => {
+    const rawData = JSON.stringify({ a: 1 });
+    const response = await urllib.request(`${_url}multipart`, {
+      files: {
+        'buffer.js': Buffer.from(rawData),
+        'readable.js': Readable.from([ rawData ]),
+      },
+      data: {
+        hello: 'hello world，😄😓',
+        foo: 'bar',
+      },
+      dataType: 'json',
+    });
+    assert.equal(response.status, 200);
+    // console.log(response.data);
+    assert.equal(response.data.method, 'POST');
+    assert.match(response.data.headers['content-type'], /^multipart\/form-data;/);
+
+    assert.equal(response.data.files['readable.js'].filename, 'readable.js');
+    // set mimeType by filename
+    assert.equal(response.data.files['readable.js'].mimeType, 'application/javascript');
+
+    assert.equal(response.data.files['buffer.js'].filename, 'buffer.js');
+    assert.equal(response.data.files['buffer.js'].mimeType, 'application/octet-stream');
+    assert.equal(response.data.files['buffer.js'].size, rawData.length);
+
     assert.equal(response.data.form.hello, 'hello world，😄😓');
     assert.equal(response.data.form.foo, 'bar');
   });


### PR DESCRIPTION
> Uploading files with Buffer defaults the filename to the key or path, which can conflict with middleware checks.

* 🤖 files as an object defaults filename to the key.
~~* 🚨 File paths or streams also override the filename.~~
* ♻️ only work for buffer scence.
----------

> 当直接通过 Buffer 来上传文件时，无法自定义文件名，这在某些中间件会校验 filename，导致无法上传。

* 🤖 files 参数为 object 时，默认将 key 作为文件名传输
~~* 🚨 传入文件路径或 Readable 流时也同样覆盖~~
* ♻️ 仅处理 buffer 场景


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced file upload functionality to support optional custom file names, allowing users to specify filenames when uploading files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->