### PR TITLE
test: use oxlint instead of eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "eslint-config-egg/typescript",
-    "eslint-config-egg/lib/rules/enforce-node-prefix"
-  ]
-}

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://registry.npmmirror.com/oxlint/latest/files/configuration_schema.json",
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "eqeqeq": "error",
+    "semi": "error",
+    "no-unused-vars": "error",
+    "no-eq-null": "error",
+    "no-eval": "error",
+    "no-regex-spaces": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/node-modules/urllib.git"
   },
   "scripts": {
-    "lint": "oxlint",
+    "lint": "oxlint -c oxlintrc.json",
     "prebuild": "npm run clean",
     "build": "tsc --version && tshy && tshy-after && npm run build:version",
     "postbuild": "rm -rf *.tsbuildinfo",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "npm run lint && vitest run",
     "test-keepalive": "cross-env TEST_KEEPALIVE_COUNT=50 vitest run --test-timeout 180000 keep-alive-header.test.ts",
     "cov": "vitest run --coverage",
-    "ci": "npm run lint && npm run cov && npm run prepublishOnly && attw --pack",
+    "ci": "npm run cov && npm run prepublishOnly && attw --pack",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/node-modules/urllib.git"
   },
   "scripts": {
-    "lint": "eslint src test --ext .ts --cache",
+    "lint": "oxlint",
     "prebuild": "npm run clean",
     "build": "tsc --version && tshy && tshy-after && npm run build:version",
     "postbuild": "rm -rf *.tsbuildinfo",
@@ -54,8 +54,6 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",
     "@eggjs/tsconfig": "^1.3.3",
-    "@tsconfig/node18": "^18.2.1",
-    "@tsconfig/strictest": "^2.0.2",
     "@types/busboy": "^1.5.0",
     "@types/mime-types": "^2.1.1",
     "@types/node": "^20.2.1",
@@ -66,9 +64,8 @@
     "@vitest/coverage-v8": "^1.6.0",
     "busboy": "^1.6.0",
     "cross-env": "^7.0.3",
-    "eslint": "8",
-    "eslint-config-egg": "13",
     "iconv-lite": "^0.6.3",
+    "oxlint": "^0.5.0",
     "proxy": "^1.0.2",
     "selfsigned": "^2.0.1",
     "tar-stream": "^2.2.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,6 @@ const JSONCtlCharsMap: Record<string, string> = {
   '\r': '\\r', // \u000d
   '\t': '\\t', // \u0009
 };
-/* eslint no-control-regex: "off"*/
 const JSONCtlCharsRE = /[\u0000-\u001F\u005C]/g;
 
 function replaceOneChar(c: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,14 +12,20 @@ const JSONCtlCharsMap: Record<string, string> = {
   '\r': '\\r', // \u000d
   '\t': '\\t', // \u0009
 };
+// eslint-disable-next-line
 const JSONCtlCharsRE = /[\u0000-\u001F\u005C]/g;
 
 function replaceOneChar(c: string) {
-  return JSONCtlCharsMap[c] || '\\u' + (c.charCodeAt(0) + 0x10000).toString(16).substring(1);
+  return JSONCtlCharsMap[c] || '\\u' + (c.charCodeAt(0) + 0x10000).toString(16).substring(1)
 }
 
 function replaceJSONCtlChars(value: string) {
   return value.replace(JSONCtlCharsRE, replaceOneChar);
+}
+
+let a = 1;
+if (a === null) {
+
 }
 
 export function parseJSON(data: string, fixJSONCtlChars?: FixJSONCtlChars) {
@@ -28,7 +34,7 @@ export function parseJSON(data: string, fixJSONCtlChars?: FixJSONCtlChars) {
   } else if (fixJSONCtlChars) {
     // https://github.com/node-modules/urllib/pull/77
     // remote the control characters (U+0000 through U+001F)
-    data = replaceJSONCtlChars(data);
+      data = replaceJSONCtlChars(data);
   }
   try {
     data = JSON.parse(data);

--- a/test/mts/tsconfig.json
+++ b/test/mts/tsconfig.json
@@ -1,5 +1,4 @@
 {
-	"extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node18/tsconfig"],
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
 		"outDir": "dist",

--- a/test/options.dataType.test.ts
+++ b/test/options.dataType.test.ts
@@ -141,7 +141,7 @@ describe('options.dataType.test.ts', () => {
     }, (err: any) => {
       // console.error(err);
       assert.equal(err.name, 'JSONResponseFormatError');
-      assert.match(err.message, /\" \.\.\.skip\.\.\. \"/);
+      assert.match(err.message, /" \.\.\.skip\.\.\. "/);
       assert.equal(err.res.status, 200);
       assert.equal(err.res.headers['content-type'], 'application/json');
       return true;

--- a/test/options.fixJSONCtlChars.test.ts
+++ b/test/options.fixJSONCtlChars.test.ts
@@ -24,7 +24,7 @@ describe('options.fixJSONCtlChars.test.ts', () => {
     assert.equal(response.status, 200);
     // console.log(response.data);
     assert.deepEqual(response.data, {
-      foo: '\b\f\n\r\tbar\u000e!1!\u0086!2\!\u0000\!3\!\u001f\!4\!\\\!5\!end\\\\',
+      foo: '\b\f\n\r\tbar\u000e!1!\u0086!2!\u0000!3!\u001f!4!\\\!5!end\\\\',
     });
   });
 

--- a/test/user-agent.test.ts
+++ b/test/user-agent.test.ts
@@ -22,7 +22,7 @@ describe('keep-alive-header.test.ts', () => {
     });
     assert.equal(response.status, 200);
     // console.log(response.data.headers);
-    assert.match(response.data.headers['user-agent'], /^node\-urllib\/VERSION Node\.js\/\d+\.\d+\.\d+ \(/);
+    assert.match(response.data.headers['user-agent'], /^node-urllib\/VERSION Node\.js\/\d+\.\d+\.\d+ \(/);
   });
 
   it('should return no user agent if user-agent header is set to empty string', async () => {


### PR DESCRIPTION
https://github.com/eggjs/egg/issues/5329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Switched linting script from `eslint` to `oxlint` for improved code quality checks.
	- Removed unnecessary dependencies: `@tsconfig/node18` and `@tsconfig/strictest`.
	- Updated dependency list by removing specific versions of `eslint` and `eslint-config-egg`, and adding `oxlint`.

- **Style**
	- Cleaned up code by removing unnecessary commented-out ESLint directives.

- **Tests**
	- Updated test cases to correct regular expression patterns and improve readability.
	- Adjusted JSON response assertions to remove unnecessary escape characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->