### PR TITLE
fix: uncaught exception due to second response with digest auth

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -562,6 +562,8 @@ export class HttpClient extends EventEmitter {
             // FIXME: merge exists cookie header
             requestOptions.headers.cookie = response.headers['set-cookie'].join(';');
           }
+          // Ensure the previous response is consumed as we re-use the same variable
+          await response.body.arrayBuffer();
           response = await undiciRequest(requestUrl, requestOptions as UndiciRequestOption);
         }
       }


### PR DESCRIPTION
In rare cases, an uncaught exception can happen with digest auth because of the re-use of the same variable representing the `response`.

Demonstration of the issue:
![image](https://github.com/user-attachments/assets/31464a41-9494-4837-a9d5-d135be5ca027)
Can cause this crash, the exception have not been caught by the `try-catch` block:
![crash](https://github.com/user-attachments/assets/e406164b-21b0-458e-bd79-7993aa5814aa)

I fixed the issue by consuming the initial response body before sending a new request:
![image](https://github.com/user-attachments/assets/138dc59e-1655-40ef-9914-e6b2fb6e620b)
![no-crash](https://github.com/user-attachments/assets/48d51fd7-e6f4-4e75-8b78-959c8bb066af)
  
Another way to fix this could be to use a dedicated variable for each response, but the first response may need to be closed anyway to avoid potential memory issue.  
This issue exists in both version 4.2 and 3.22.2 (tested).