### PR TITLE
feat: Added support for x-www-authenticate header

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -546,10 +546,10 @@ export class HttpClient extends EventEmitter {
       }
 
       let response = await undiciRequest(requestUrl, requestOptions as UndiciRequestOption);
-      if (response.statusCode === 401 && response.headers['www-authenticate'] &&
+      if (response.statusCode === 401 && (response.headers['www-authenticate'] || response.headers['x-www-authenticate']) &&
         !requestOptions.headers.authorization && args.digestAuth) {
         // handle digest auth
-        const authenticateHeaders = response.headers['www-authenticate'];
+        const authenticateHeaders = response.headers['www-authenticate'] ?? response.headers['x-www-authenticate'];
         const authenticate = Array.isArray(authenticateHeaders)
           ? authenticateHeaders.find(authHeader => authHeader.startsWith('Digest '))
           : authenticateHeaders;


### PR DESCRIPTION
support both headers for digestAuth: www-authenticate and x-www-authenticate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced handling of HTTP 401 Unauthorized responses to support both `www-authenticate` and `x-www-authenticate` headers for improved authentication robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->