### PR TITLE
feat: impl fetch

### DIFF
--- a/src/FetchOpaqueInterceptor.ts
+++ b/src/FetchOpaqueInterceptor.ts
@@ -1,0 +1,41 @@
+// const { AsyncLocalStorage } = require('node:async_hooks');
+import { AsyncLocalStorage } from 'node:async_hooks';
+import symbols from './symbols.js';
+import { Dispatcher } from 'undici';
+
+// const RedirectHandler = require('../handler/redirect-handler')
+
+export interface FetchOpaque {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  [symbols.kRequestId]: number;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  [symbols.kRequestStartTime]: number;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  [symbols.kEnableRequestTiming]: number;
+}
+
+// const internalOpaque = {
+//   [symbols.kRequestId]: requestId,
+//   [symbols.kRequestStartTime]: requestStartTime,
+//   [symbols.kEnableRequestTiming]: !!(init.timing ?? true),
+//   [symbols.kRequestTiming]: timing,
+//   // [symbols.kRequestOriginalOpaque]: originalOpaque,
+// };
+
+export interface OpaqueInterceptorOptions {
+  opaqueLocalStorage: AsyncLocalStorage<FetchOpaque>;
+}
+
+export function fetchOpaqueInterceptor(opts: OpaqueInterceptorOptions) {
+  const opaqueLocalStorage = opts?.opaqueLocalStorage;
+  return (dispatch: Dispatcher['dispatch']): Dispatcher['dispatch'] => {
+    return function redirectInterceptor(opts: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandlers) {
+      const opaque = opaqueLocalStorage?.getStore();
+      (handler as any).opaque = opaque;
+      return dispatch(opts, handler);
+    };
+  };
+}

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -3,6 +3,7 @@ import type { EventEmitter } from 'node:events';
 import type { Dispatcher } from 'undici';
 import type { IncomingHttpHeaders } from './IncomingHttpHeaders.js';
 import type { HttpClientResponse } from './Response.js';
+import { Request } from 'undici';
 
 export type HttpMethod = Dispatcher.HttpMethod;
 
@@ -160,4 +161,9 @@ export type RequestMeta = {
   args: RequestOptions;
   ctx?: unknown;
   retries: number;
+};
+
+export type FetchMeta = {
+  requestId: number;
+  request: Request,
 };

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   fetch as UndiciFetch,
   RequestInfo,
@@ -6,10 +7,8 @@ import {
   Response,
   Agent,
   getGlobalDispatcher,
-  Pool, Dispatcher,
-  // interceptors,
-  // Request,
-  // HeadersInit,
+  Pool,
+  Dispatcher,
 } from 'undici';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -20,27 +19,28 @@ import undiciFetchSymbols from 'undici/lib/web/fetch/symbols.js';
 import {
   channels,
   ClientOptions,
-  PoolStat, RequestDiagnosticsMessage, ResponseDiagnosticsMessage, UnidiciTimingInfo,
-  // RequestDiagnosticsMessage,
+  PoolStat,
+  RequestDiagnosticsMessage,
+  ResponseDiagnosticsMessage,
+  UnidiciTimingInfo,
 } from './HttpClient.js';
 import {
-  HttpAgent, HttpAgentOptions,
-  // CheckAddressFunction,
+  HttpAgent,
+  HttpAgentOptions,
 } from './HttpAgent.js';
 import { initDiagnosticsChannel } from './diagnosticsChannel.js';
 import { convertHeader, globalId, performanceTime, updateSocketInfo } from './utils.js';
 import symbols from './symbols.js';
 import {
-  FetchMeta, HttpMethod, RequestMeta,
-  // RequestMeta,
+  FetchMeta,
+  HttpMethod,
+  RequestMeta,
 } from './Request.js';
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { FetchOpaque, fetchOpaqueInterceptor } from './FetchOpaqueInterceptor.js';
 import { RawResponseWithMeta, SocketInfo } from './Response.js';
 import { IncomingHttpHeaders } from './IncomingHttpHeaders.js';
 
 export interface UrllibRequestInit extends RequestInit {
-  // checkAddress?: CheckAddressFunction;
   // default is true
   timing?: boolean;
 }
@@ -179,9 +179,6 @@ export class FetchFactory {
       requestId,
       request,
     };
-    // const request = new Request(input, {
-    //
-    // });
     const socketInfo: SocketInfo = {
       id: 0,
       localAddress: '',

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,0 +1,267 @@
+import {
+  fetch as UndiciFetch,
+  RequestInfo,
+  RequestInit,
+  Request,
+  Response,
+  Agent,
+  getGlobalDispatcher,
+  Pool, Dispatcher,
+  // interceptors,
+  // Request,
+  // HeadersInit,
+} from 'undici';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import undiciSymbols from 'undici/lib/core/symbols.js';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import undiciFetchSymbols from 'undici/lib/web/fetch/symbols.js';
+import {
+  channels,
+  ClientOptions,
+  PoolStat, RequestDiagnosticsMessage, ResponseDiagnosticsMessage, UnidiciTimingInfo,
+  // RequestDiagnosticsMessage,
+} from './HttpClient.js';
+import {
+  HttpAgent, HttpAgentOptions,
+  // CheckAddressFunction,
+} from './HttpAgent.js';
+import { initDiagnosticsChannel } from './diagnosticsChannel.js';
+import { convertHeader, globalId, performanceTime, updateSocketInfo } from './utils.js';
+import symbols from './symbols.js';
+import {
+  FetchMeta, HttpMethod, RequestMeta,
+  // RequestMeta,
+} from './Request.js';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { FetchOpaque, fetchOpaqueInterceptor } from './FetchOpaqueInterceptor.js';
+import { RawResponseWithMeta, SocketInfo } from './Response.js';
+import { IncomingHttpHeaders } from './IncomingHttpHeaders.js';
+
+export interface UrllibRequestInit extends RequestInit {
+  // checkAddress?: CheckAddressFunction;
+  // default is true
+  timing?: boolean;
+}
+
+export type FetchDiagnosticsMessage = {
+  fetch: FetchMeta;
+};
+
+export type FetchResponseDiagnosticsMessage = {
+  fetch: FetchMeta;
+  timingInfo?: UnidiciTimingInfo;
+  response?: Response;
+  error?: Error;
+};
+
+export class FetchFactory {
+  static #dispatcher: Agent;
+  static #opaqueLocalStorage = new AsyncLocalStorage<FetchOpaque>();
+
+  static getDispatcher() {
+    return FetchFactory.#dispatcher ?? getGlobalDispatcher();
+  }
+
+  static setDispatcher(dispatcher: Agent) {
+    FetchFactory.#dispatcher = dispatcher;
+  }
+
+  static setClientOptions(clientOptions: ClientOptions) {
+    let dispatcherOption: Agent.Options = {
+      interceptors: {
+        Agent: [
+          fetchOpaqueInterceptor({
+            opaqueLocalStorage: FetchFactory.#opaqueLocalStorage,
+          }),
+        ],
+        Client: [],
+      },
+    };
+    let dispatcherClazz: new (options: Agent.Options) => Agent = Agent;
+    if (clientOptions?.lookup || clientOptions?.checkAddress) {
+      dispatcherOption = {
+        ...dispatcherOption,
+        lookup: clientOptions.lookup,
+        checkAddress: clientOptions.checkAddress,
+        connect: clientOptions.connect,
+        allowH2: clientOptions.allowH2,
+      } as HttpAgentOptions;
+      dispatcherClazz = HttpAgent as unknown as new (options: Agent.Options) => Agent;
+    } else if (clientOptions?.connect) {
+      dispatcherOption = {
+        ...dispatcherOption,
+        connect: clientOptions.connect,
+        allowH2: clientOptions.allowH2,
+      } as HttpAgentOptions;
+      dispatcherClazz = Agent;
+    } else if (clientOptions?.allowH2) {
+      // Support HTTP2
+      dispatcherOption = {
+        ...dispatcherOption,
+        allowH2: clientOptions.allowH2,
+      } as HttpAgentOptions;
+      dispatcherClazz = Agent;
+    }
+    FetchFactory.#dispatcher = new dispatcherClazz(dispatcherOption);
+    initDiagnosticsChannel();
+  }
+
+  static getDispatcherPoolStats() {
+    const agent = FetchFactory.getDispatcher();
+    // origin => Pool Instance
+    const clients: Map<string, WeakRef<Pool>> | undefined = Reflect.get(agent, undiciSymbols.kClients);
+    const poolStatsMap: Record<string, PoolStat> = {};
+    if (!clients) {
+      return poolStatsMap;
+    }
+    for (const [ key, ref ] of clients) {
+      const pool = typeof ref.deref === 'function' ? ref.deref() : ref as unknown as Pool;
+      const stats = pool?.stats;
+      if (!stats) continue;
+      poolStatsMap[key] = {
+        connected: stats.connected,
+        free: stats.free,
+        pending: stats.pending,
+        queued: stats.queued,
+        running: stats.running,
+        size: stats.size,
+      } satisfies PoolStat;
+    }
+    return poolStatsMap;
+  }
+
+  static async fetch(input: RequestInfo, init?: UrllibRequestInit): Promise<Response> {
+    const requestStartTime = performance.now();
+    init = init ?? {};
+    init.dispatcher = init.dispatcher ?? FetchFactory.#dispatcher;
+    const request = new Request(input, init);
+    const requestId = globalId('HttpClientRequest');
+    // https://developer.chrome.com/docs/devtools/network/reference/?utm_source=devtools#timing-explanation
+    const timing = {
+      // socket assigned
+      queuing: 0,
+      // dns lookup time
+      // dnslookup: 0,
+      // socket connected
+      connected: 0,
+      // request headers sent
+      requestHeadersSent: 0,
+      // request sent, including headers and body
+      requestSent: 0,
+      // Time to first byte (TTFB), the response headers have been received
+      waiting: 0,
+      // the response body and trailers have been received
+      contentDownload: 0,
+    };
+
+    // using opaque to diagnostics channel, binding request and socket
+    const internalOpaque = {
+      [symbols.kRequestId]: requestId,
+      [symbols.kRequestStartTime]: requestStartTime,
+      [symbols.kEnableRequestTiming]: !!(init.timing ?? true),
+      [symbols.kRequestTiming]: timing,
+      // [symbols.kRequestOriginalOpaque]: originalOpaque,
+    };
+    const reqMeta: RequestMeta = {
+      requestId,
+      url: request.url,
+      args: {
+        method: request.method as HttpMethod,
+        type: request.method as HttpMethod,
+        data: request.body,
+        headers: convertHeader(request.headers),
+      },
+      retries: 0,
+    };
+    const fetchMeta: FetchMeta = {
+      requestId,
+      request,
+    };
+    // const request = new Request(input, {
+    //
+    // });
+    const socketInfo: SocketInfo = {
+      id: 0,
+      localAddress: '',
+      localPort: 0,
+      remoteAddress: '',
+      remotePort: 0,
+      remoteFamily: '',
+      bytesWritten: 0,
+      bytesRead: 0,
+      handledRequests: 0,
+      handledResponses: 0,
+    };
+    channels.request.publish({
+      request: reqMeta,
+    } as RequestDiagnosticsMessage);
+    channels.fetchRequest.publish({
+      fetch: fetchMeta,
+    } as FetchDiagnosticsMessage);
+
+    let res: Response;
+    // keep urllib createCallbackResponse style
+    const resHeaders: IncomingHttpHeaders = {};
+    const urllibResponse = {
+      status: -1,
+      statusCode: -1,
+      statusText: '',
+      statusMessage: '',
+      headers: resHeaders,
+      size: 0,
+      aborted: false,
+      rt: 0,
+      keepAliveSocket: true,
+      requestUrls: [
+        request.url,
+      ],
+      timing,
+      socket: socketInfo,
+      retries: 0,
+      socketErrorRetries: 0,
+    } as any as RawResponseWithMeta;
+    try {
+      await FetchFactory.#opaqueLocalStorage.run(internalOpaque, async () => {
+        res = await UndiciFetch(input, init);
+      });
+    } catch (e: any) {
+      channels.response.publish({
+        fetch: fetchMeta,
+        error: e,
+      } as FetchResponseDiagnosticsMessage);
+      channels.fetchResponse.publish({
+        request: reqMeta,
+        response: urllibResponse,
+        error: e,
+      } as ResponseDiagnosticsMessage);
+      throw e;
+    }
+
+    // get unidici internal response
+    const state = Reflect.get(res!, undiciFetchSymbols.kState) as Dispatcher.ResponseData;
+    updateSocketInfo(socketInfo, internalOpaque /* , rawError */);
+
+    urllibResponse.headers = convertHeader(res!.headers);
+    urllibResponse.status = urllibResponse.statusCode = res!.status;
+    urllibResponse!.statusMessage = res!.statusText;
+    if (urllibResponse.headers['content-length']) {
+      urllibResponse.size = parseInt(urllibResponse.headers['content-length']);
+    }
+    urllibResponse.rt = performanceTime(requestStartTime);
+
+    channels.fetchResponse.publish({
+      fetch: fetchMeta,
+      timingInfo: (state as any).timingInfo,
+      response: res!,
+    } as FetchResponseDiagnosticsMessage);
+    channels.response.publish({
+      request: reqMeta,
+      response: urllibResponse,
+    } as ResponseDiagnosticsMessage);
+    return res!;
+  }
+}
+
+export const fetch = FetchFactory.fetch;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ export async function curl<T = any>(url: RequestURL, options?: RequestOptions) {
 export {
   MockAgent, ProxyAgent, Agent, Dispatcher,
   setGlobalDispatcher, getGlobalDispatcher,
+  Request, RequestInfo, RequestInit,
+  Response,
 } from 'undici';
 // HttpClient2 is keep compatible with urllib@2 HttpClient2
 export {
@@ -60,6 +62,7 @@ export {
   IncomingHttpHeaders,
 } from './IncomingHttpHeaders.js';
 export * from './HttpClientError.js';
+export { FetchFactory, fetch } from './fetch.js';
 
 export default {
   request,

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import { startServer } from './fixtures/server.js';
+import { fetch, FetchDiagnosticsMessage, FetchFactory, FetchResponseDiagnosticsMessage } from '../src/fetch.js';
+import { RequestDiagnosticsMessage, ResponseDiagnosticsMessage } from '../src/HttpClient.js';
+import diagnosticsChannel from 'node:diagnostics_channel';
+
+describe('fetch.test.ts', () => {
+  let close: any;
+  let _url: string;
+  beforeAll(async () => {
+    const { closeServer, url } = await startServer();
+    close = closeServer;
+    _url = url;
+  });
+
+  afterAll(async () => {
+    await close();
+  });
+
+
+  it('fetch should work', async () => {
+    let requestDiagnosticsMessage: RequestDiagnosticsMessage;
+    let responseDiagnosticsMessage: ResponseDiagnosticsMessage;
+    let fetchDiagnosticsMessage: FetchDiagnosticsMessage;
+    let fetchResponseDiagnosticsMessage: FetchResponseDiagnosticsMessage;
+    diagnosticsChannel.subscribe('urllib:request', msg => {
+      requestDiagnosticsMessage = msg as RequestDiagnosticsMessage;
+    });
+    diagnosticsChannel.subscribe('urllib:response', msg => {
+      responseDiagnosticsMessage = msg as ResponseDiagnosticsMessage;
+    });
+    diagnosticsChannel.subscribe('urllib:fetch:request', msg => {
+      fetchDiagnosticsMessage = msg as FetchDiagnosticsMessage;
+    });
+    diagnosticsChannel.subscribe('urllib:fetch:response', msg => {
+      fetchResponseDiagnosticsMessage = msg as FetchResponseDiagnosticsMessage;
+    });
+    FetchFactory.setClientOptions({});
+
+    const response = await fetch(`${_url}html`);
+
+    assert(response);
+    assert(requestDiagnosticsMessage!.request);
+    assert(responseDiagnosticsMessage!.request);
+    assert(responseDiagnosticsMessage!.response);
+
+    assert(fetchDiagnosticsMessage!.fetch);
+    assert(fetchResponseDiagnosticsMessage!.fetch);
+    assert(fetchResponseDiagnosticsMessage!.response);
+    assert(fetchResponseDiagnosticsMessage!.timingInfo);
+
+    const stats = FetchFactory.getDispatcherPoolStats();
+    assert(stats);
+    assert(Object.keys(stats).length > 0);
+  });
+});


### PR DESCRIPTION
- keep urllib:request, urllib:response channel message
- add urllib:fetch:request, urllib:fetch:response channel message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `FetchFactory` class for enhanced HTTP request management with diagnostics.
  - Added a new `FetchOpaque` type for tracking request metadata.
  - Enhanced `HttpClient` with new timing and diagnostics capabilities.
  
- **Bug Fixes**
  - Improved error handling for socket-related issues in `HttpClient`.

- **Documentation**
  - Expanded public exports for better usability, including new interfaces and constants.

- **Tests**
  - Added unit tests for the new `fetch` functionality to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->