### PR TITLE
fix: only set extend notation on non-ascii filename

### DIFF
--- a/src/FormData.ts
+++ b/src/FormData.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
 import _FormData from 'form-data';
 
+// eslint-disable-next-line
+const ASCII_RE = /[^\x00-\x7F]/i;
+
 export class FormData extends _FormData {
   _getContentDisposition(value: any, options: any) {
     // support non-ascii filename
@@ -24,7 +27,10 @@ export class FormData extends _FormData {
     if (filename) {
       // https://datatracker.ietf.org/doc/html/rfc6266#section-4.1
       // support non-ascii filename
-      contentDisposition = 'filename="' + filename + '"; filename*=UTF-8\'\'' + encodeURIComponent(filename);
+      contentDisposition = 'filename="' + filename + '"';
+      if (ASCII_RE.test(filename)) {
+        contentDisposition += '; filename*=UTF-8\'\'' + encodeURIComponent(filename);
+      }
     }
 
     return contentDisposition;

--- a/src/FormData.ts
+++ b/src/FormData.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import _FormData from 'form-data';
 
 // eslint-disable-next-line
-const ASCII_RE = /[^\x00-\x7F]/i;
+const NON_ASCII_RE = /[^\x00-\x7F]/i;
 
 export class FormData extends _FormData {
   _getContentDisposition(value: any, options: any) {
@@ -28,7 +28,7 @@ export class FormData extends _FormData {
       // https://datatracker.ietf.org/doc/html/rfc6266#section-4.1
       // support non-ascii filename
       contentDisposition = 'filename="' + filename + '"';
-      if (ASCII_RE.test(filename)) {
+      if (NON_ASCII_RE.test(filename)) {
         contentDisposition += '; filename*=UTF-8\'\'' + encodeURIComponent(filename);
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced filename handling to include UTF-8 encoding for non-ASCII filenames in content disposition.
  
- **Bug Fixes**
	- Improved logic for constructing content disposition strings based on filename character set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->