### PR TITLE
fix: set opaque on request

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -300,7 +300,7 @@ export class HttpClient extends EventEmitter {
       // socket assigned
       queuing: 0,
       // dns lookup time
-      // dnslookup: 0,
+      dnslookup: 0,
       // socket connected
       connected: 0,
       // request headers sent

--- a/src/Response.ts
+++ b/src/Response.ts
@@ -28,7 +28,7 @@ export type Timing = {
   // socket assigned
   queuing: number;
   // dns lookup time
-  // dnslookup: number;
+  dnslookup: number;
   // socket connected
   connected: number;
   // request headers sent

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -17,5 +17,6 @@ export default {
   kEnableRequestTiming: Symbol('enable request timing or not'),
   kRequestTiming: Symbol('request timing'),
   kRequestOriginalOpaque: Symbol('request original opaque'),
+  kRequestInternalOpaque: Symbol('request internal opaque'),
   kErrorSocket: Symbol('socket of error'),
 };

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import diagnosticsChannel from 'node:diagnostics_channel';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import { startServer } from './fixtures/server.js';
 import {
@@ -20,7 +21,6 @@ describe('fetch.test.ts', () => {
     await close();
   });
 
-
   it('fetch should work', async () => {
     let requestDiagnosticsMessage: RequestDiagnosticsMessage;
     let responseDiagnosticsMessage: ResponseDiagnosticsMessage;
@@ -40,18 +40,26 @@ describe('fetch.test.ts', () => {
     });
     FetchFactory.setClientOptions({});
 
-    const response = await fetch(`${_url}html`);
+    let response = await fetch(`${_url}html`);
 
     assert(response);
     assert(requestDiagnosticsMessage!.request);
     assert(responseDiagnosticsMessage!.request);
     assert(responseDiagnosticsMessage!.response);
+    assert(responseDiagnosticsMessage!.response.socket.localAddress);
     assert([ '127.0.0.1', '::1' ].includes(responseDiagnosticsMessage!.response.socket.localAddress));
 
     assert(fetchDiagnosticsMessage!.fetch);
     assert(fetchResponseDiagnosticsMessage!.fetch);
     assert(fetchResponseDiagnosticsMessage!.response);
     assert(fetchResponseDiagnosticsMessage!.timingInfo);
+
+    await sleep(1);
+    // again, keep alive
+    response = await fetch(`${_url}html`);
+    // console.log(responseDiagnosticsMessage!.response.socket);
+    assert(responseDiagnosticsMessage!.response.socket.handledRequests > 1);
+    assert(responseDiagnosticsMessage!.response.socket.handledResponses > 1);
 
     const stats = FetchFactory.getDispatcherPoolStats();
     assert(stats);
@@ -77,17 +85,21 @@ describe('fetch.test.ts', () => {
     });
     FetchFactory.setClientOptions({});
 
-    try {
+    await assert.rejects(async () => {
       await fetch(`${_url}html?timeout=9999`, {
         signal: AbortSignal.timeout(100),
       });
-    } catch (error) {
-      console.log(error);
-    }
+    }, (err: any) => {
+      assert.equal(err.name, 'TimeoutError');
+      assert.equal(err.message, 'The operation was aborted due to timeout');
+      return true;
+    });
 
     assert(requestDiagnosticsMessage!.request);
     assert(responseDiagnosticsMessage!.request);
     assert(responseDiagnosticsMessage!.response);
+    // console.log(responseDiagnosticsMessage!.response.socket);
+    assert(responseDiagnosticsMessage!.response.socket.localAddress);
     assert([ '127.0.0.1', '::1' ].includes(responseDiagnosticsMessage!.response.socket.localAddress));
 
     assert(fetchDiagnosticsMessage!.fetch);

--- a/test/options.timing.test.ts
+++ b/test/options.timing.test.ts
@@ -32,7 +32,7 @@ describe('options.timing.test.ts', () => {
     assert(res.timing.contentDownload > 0);
     assert(res.timing.contentDownload > res.timing.waiting);
     assert(res.timing.contentDownload <= res.rt);
-    assert(res.socket.handledResponses === 1);
+    assert.equal(res.socket.handledResponses, 1);
 
     // again connected should be zero
     await sleep(1);
@@ -45,13 +45,14 @@ describe('options.timing.test.ts', () => {
     res = response.res as RawResponseWithMeta;
     assert(res.timing.waiting > 0);
     assert(res.timing.queuing > 0);
-    assert(res.timing.connected === 0);
+    assert.equal(res.timing.connected, 0);
     assert(res.timing.requestHeadersSent > 0);
     assert(res.timing.requestSent > 0);
     assert(res.timing.contentDownload > 0);
     assert(res.timing.contentDownload > res.timing.waiting);
     assert(res.timing.contentDownload <= res.rt);
-    assert(res.socket.handledResponses === 2);
+    assert.equal(res.socket.handledResponses, 2);
+    // console.log(res.timing);
   });
 
   it('should timing = false work', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced timing metrics for HTTP requests, now including `dnslookup`.
	- Improved logging format for better clarity in debug outputs.

- **Bug Fixes**
	- Refined error handling for various timeout errors, improving granularity in error reporting.
	- Enhanced error handling in fetch operations with detailed logging of request IDs and errors.

- **Tests**
	- Updated test cases for fetch functionality to include timing assertions and improved error handling checks.
	- Enhanced clarity in assertions within timing tests.

- **Chores**
	- Added a new symbol for representing internal opaque request values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->