### PR TITLE
fix: should not throw when fetch a Request with post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/fixtures/ts-cjs-es2021/*.js
 test/fixtures/ts-esm/*.js
 .eslintcache
 .tshy*
+.idea/

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -218,7 +218,7 @@ export class FetchFactory {
     } as any as RawResponseWithMeta;
     try {
       await FetchFactory.#opaqueLocalStorage.run(internalOpaque, async () => {
-        res = await UndiciFetch(request, init);
+        res = await UndiciFetch(request);
       });
     } catch (e: any) {
       updateSocketInfo(socketInfo, internalOpaque, e);

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -218,7 +218,7 @@ export class FetchFactory {
     } as any as RawResponseWithMeta;
     try {
       await FetchFactory.#opaqueLocalStorage.run(internalOpaque, async () => {
-        res = await UndiciFetch(input, init);
+        res = await UndiciFetch(request, init);
       });
     } catch (e: any) {
       updateSocketInfo(socketInfo, internalOpaque, e);

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -7,6 +7,7 @@ import {
   fetch, FetchDiagnosticsMessage, FetchFactory, FetchResponseDiagnosticsMessage,
 } from '../src/fetch.js';
 import { RequestDiagnosticsMessage, ResponseDiagnosticsMessage } from '../src/HttpClient.js';
+import { Request } from 'undici';
 
 describe('fetch.test.ts', () => {
   let close: any;
@@ -108,5 +109,15 @@ describe('fetch.test.ts', () => {
     const stats = FetchFactory.getDispatcherPoolStats();
     assert(stats);
     assert(Object.keys(stats).length > 0);
+  });
+
+  it('fetch request with post should work', async () => {
+    await assert.doesNotReject(async () => {
+      const request = new Request(_url, {
+        method: 'POST',
+        body: 'test-body',
+      });
+      await fetch(request);
+    }, /Cannot construct a Request with a Request object that has already been used/);
   });
 });


### PR DESCRIPTION
## 现象
使用 post method fetch 一个 Request 对象时会出现 `Cannot construct a Request with a Request object that has already been used.` 错误。

## 原因
Request 的 constructor 会把入参的 request.body.stream.locked 变为 true，urllib 的 fetch 中已经使用参数 input new 了一个 Request，再调用 undici fetch 时参数还是 input，就会报错。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the fetch method to utilize a `Request` object for improved request handling.
	- Added a new test case to verify POST request functionality using the `Request` class.

- **Chores**
	- Updated `.gitignore` to exclude the `.idea/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->