### PR TITLE
fix:  compressed option should be false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ console.log('status: %s, body size: %d, headers: %j', res.status, data.length, r
   - ***formatRedirectUrl*** Function - Format the redirect url by your self. Default is `url.resolve(from, to)`.
   - ***beforeRequest*** Function - Before request hook, you can change every thing here.
   - ***streaming*** Boolean - let you get the `res` object when request  connected, default `false`. alias `customResponse`
-  - ***compressed*** Boolean - Accept `gzip, br` response content and auto decode it, default is `true`.
+  - ***compressed*** Boolean - Accept `gzip, br` response content and auto decode it, default is `false`.
   - ***timing*** Boolean - Enable timing or not, default is `true`.
   - ***socketPath*** String | null - request a unix socket service, default is `null`.
   - ***highWaterMark*** Number - default is `67108864`, 64 KiB.

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -105,7 +105,7 @@ export type RequestOptions = {
   formatRedirectUrl?: (a: any, b: any) => void;
   /** Before request hook, you can change every thing here. */
   beforeRequest?: (...args: any[]) => void;
-  /** Accept `gzip, br` response content and auto decode it, default is `true`. */
+  /** Accept `gzip, br` response content and auto decode it, default is `false`. */
   compressed?: boolean;
   /**
    * @deprecated


### PR DESCRIPTION
The `compressed` option is not enabled by default. There is no code setting it to true, except where the old `gzip` property is true. I confirmed this behavior in testing. The documentation for it appears to have been inadvertently updated when the `timing` option was added in commit 1d26bb8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated `README.md` to reflect the change in default value for the `compressed` option in the `async request(url[, options])` method from `true` to `false`.
  
- **Bug Fixes**
	- Changed the default behavior of the `compressed` property in request handling to prevent automatic decoding of `gzip` and `br` responses unless specified by the user.

- **Chores**
	- Deprecated the `ctx` property in `RequestOptions`, recommending the use of the `opaque` property instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->