### PR TITLE
Revert "fix: patch undici File support on Node.js < 20 (#588)"

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -429,7 +429,7 @@ export class HttpClient extends EventEmitter {
       const requestOptions: IUndiciRequestOption = {
         method,
         // disable undici auto redirect handler
-        // maxRedirections: 0,
+        maxRedirections: 0,
         headersTimeout,
         headers,
         bodyTimeout,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { LRU } from 'ylru';
 import { patchForNode16 } from './utils.js';
 
-
 patchForNode16();
 
 import { HttpClient, HEADER_USER_AGENT } from './HttpClient.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,7 @@ import { randomBytes, createHash } from 'node:crypto';
 import { Readable } from 'node:stream';
 import { performance } from 'node:perf_hooks';
 import { ReadableStream, TransformStream } from 'node:stream/web';
-import { Blob, File } from 'node:buffer';
-import { toUSVString } from 'node:util';
+import { Blob } from 'node:buffer';
 import type { FixJSONCtlChars } from './Request.js';
 import { SocketInfo } from './Response.js';
 import symbols from './symbols.js';
@@ -232,37 +231,6 @@ export function patchForNode16() {
     // @ts-ignore
     global.DOMException = getDOMExceptionClass();
   }
-  // multi undici version in node version less than 20 https://github.com/nodejs/undici/issues/4374
-  if (typeof global.File === 'undefined') {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    global.File = File;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (String.prototype.toWellFormed === undefined) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    String.prototype.toWellFormed = function() {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return toUSVString(this);
-    };
-  }
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (String.prototype.isWellFormed === undefined) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    String.prototype.isWellFormed = function() {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return toUSVString(this) === this;
-    };
-  }
-
 }
 
 // https://github.com/jimmywarting/node-domexception/blob/main/index.js

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -8,11 +8,8 @@ import { describe, it, beforeAll, afterAll } from 'vitest';
 import selfsigned from 'selfsigned';
 import { HttpClient, RawResponseWithMeta, getGlobalDispatcher } from '../src/index.js';
 import { startServer } from './fixtures/server.js';
-import { nodeMajorVersion } from './utils.js';
 
-const pems = selfsigned.generate([], {
-  keySize: nodeMajorVersion() >= 22 ? 2048 : 1024,
-});
+const pems = selfsigned.generate();
 
 if (process.env.ENABLE_PERF) {
   const obs = new PerformanceObserver(items => {

--- a/test/diagnostics_channel.test.ts
+++ b/test/diagnostics_channel.test.ts
@@ -12,7 +12,6 @@ import type {
 } from '../src/index.js';
 import symbols from '../src/symbols.js';
 import { startServer } from './fixtures/server.js';
-import { nodeMajorVersion } from './utils.js';
 
 describe('diagnostics_channel.test.ts', () => {
   let close: any;
@@ -144,9 +143,7 @@ describe('diagnostics_channel.test.ts', () => {
   });
 
   it('should support trace socket info with H2 by undici:client:sendHeaders and undici:request:trailers', async () => {
-    const pem = selfsigned.generate([], {
-      keySize: nodeMajorVersion() >= 22 ? 2048 : 1024,
-    });
+    const pem = selfsigned.generate();
     const server = createSecureServer({
       key: pem.private,
       cert: pem.cert,

--- a/test/fixtures/server.ts
+++ b/test/fixtures/server.ts
@@ -8,7 +8,7 @@ import busboy from 'busboy';
 import iconv from 'iconv-lite';
 import selfsigned from 'selfsigned';
 import qs from 'qs';
-import { nodeMajorVersion, readableToBytes } from '../utils.js';
+import { readableToBytes } from '../utils.js';
 
 const requestsPerSocket = Symbol('requestsPerSocket');
 
@@ -370,9 +370,7 @@ export async function startServer(options?: {
   };
 
   if (options?.https) {
-    const pem = selfsigned.generate([], {
-      keySize: nodeMajorVersion() >= 22 ? 2048 : 1024,
-    });
+    const pem = selfsigned.generate();
     server = createHttpsServer({
       key: pem.private,
       cert: pem.cert,

--- a/test/options.stream.test.ts
+++ b/test/options.stream.test.ts
@@ -94,7 +94,7 @@ describe('options.stream.test.ts', () => {
     assert.equal(response.headers['content-type'], 'application/json');
     assert.equal(response.data.method, 'POST');
     // console.log(response.data);
-    // assert.match(response.data.headers['content-type'], /^multipart\/form-data; boundary=--------------------------\d+$/);
+    assert.match(response.data.headers['content-type'], /^multipart\/form-data; boundary=--------------------------\d+$/);
     assert.equal(response.data.files.file.filename, 'options.stream.test.ts');
     assert.equal(response.data.form.hello, '你好 urllib 3');
     const raw = await readFile(__filename);

--- a/test/options.timeout.test.ts
+++ b/test/options.timeout.test.ts
@@ -5,11 +5,8 @@ import selfsigned from 'selfsigned';
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import urllib, { HttpClientRequestTimeoutError, HttpClient } from '../src/index.js';
 import { startServer } from './fixtures/server.js';
-import { nodeMajorVersion } from './utils.js';
 
-const pems = selfsigned.generate([], {
-  keySize: nodeMajorVersion() >= 22 ? 2048 : 1024,
-});
+const pems = selfsigned.generate();
 
 describe('options.timeout.test.ts', () => {
   let close: any;

--- a/test/urllib.options.rejectUnauthorized-false.test.ts
+++ b/test/urllib.options.rejectUnauthorized-false.test.ts
@@ -5,7 +5,6 @@ import { describe, it, beforeAll, afterAll } from 'vitest';
 import selfsigned from 'selfsigned';
 import urllib, { HttpClient } from '../src/index.js';
 import { startServer } from './fixtures/server.js';
-import { nodeMajorVersion } from './utils.js';
 
 describe('urllib.options.rejectUnauthorized-false.test.ts', () => {
   let close: any;
@@ -30,9 +29,7 @@ describe('urllib.options.rejectUnauthorized-false.test.ts', () => {
   });
 
   it('should 200 with H2 on options.rejectUnauthorized = false', async () => {
-    const pem = selfsigned.generate([], {
-      keySize: nodeMajorVersion() >= 22 ? 2048 : 1024,
-    });
+    const pem = selfsigned.generate();
     const server = createSecureServer({
       key: pem.private,
       cert: pem.cert,


### PR DESCRIPTION
This reverts commit 0e5ad194241c2511ac0d333937ed840e24cbcb77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redirects are now handled consistently by the client, honoring redirect limits and followRedirect=false.

* **Refactor**
  * Removed Node 16 compatibility shims, effectively ending Node 16 support. No public API changes.

* **Tests**
  * Simplified TLS certificate generation across tests.
  * Re-enabled multipart Content-Type assertion for form upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->