### PR TITLE
chore: enable oxfmt jsdoc feature

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -76,36 +76,32 @@ export type ClientOptions = {
   defaultArgs?: RequestOptions;
   /** Allow to use HTTP2 first. Default is `false` */
   allowH2?: boolean;
-  /**
-   * Custom DNS lookup function, default is `dns.lookup`.
-   */
+  /** Custom DNS lookup function, default is `dns.lookup`. */
   lookup?: LookupFunction;
   /**
-   * check request address to protect from SSRF and similar attacks.
-   * It receive two arguments(ip and family) and should return true or false to identified the address is legal or not.
-   * It rely on lookup and have the same version requirement.
+   * Check request address to protect from SSRF and similar attacks. It receive two arguments(ip and family) and should
+   * return true or false to identified the address is legal or not. It rely on lookup and have the same version
+   * requirement.
    */
   checkAddress?: CheckAddressFunction;
   connect?: {
     key?: string | Buffer;
     /**
-     * A string or Buffer containing the certificate key of the client in PEM format.
-     * Notes: This is necessary only if using the client certificate authentication
+     * A string or Buffer containing the certificate key of the client in PEM format. Notes: This is necessary only if
+     * using the client certificate authentication
      */
     cert?: string | Buffer;
     /**
-     * If `true`, the server certificate is verified against the list of supplied CAs.
-     * An 'error' event is emitted if verification fails.
-     * Default: `true`
+     * If `true`, the server certificate is verified against the list of supplied CAs. An 'error' event is emitted if
+     * verification fails. Default: `true`
      */
     rejectUnauthorized?: boolean;
     /**
-     * socketPath string | null (optional) - Default: null - An IPC endpoint, either Unix domain socket or Windows named pipe
+     * SocketPath string | null (optional) - Default: null - An IPC endpoint, either Unix domain socket or Windows named
+     * pipe
      */
     socketPath?: string | null;
-    /**
-     * connect timeout, default is 10000ms
-     */
+    /** Connect timeout, default is 10000ms */
     timeout?: number;
   };
 };

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -32,14 +32,13 @@ export type RequestOptions = {
    */
   stream?: Readable;
   /**
-   * A writable stream to be piped by the response stream.
-   * Responding data will be write to this stream and callback
+   * A writable stream to be piped by the response stream. Responding data will be write to this stream and callback
    * will be called with data set null after finished writing.
    */
   writeStream?: Writable;
   /**
-   * The files will send with multipart/form-data format, base on formstream.
-   * If method not set, will use POST method by default.
+   * The files will send with multipart/form-data format, base on formstream. If method not set, will use POST method by
+   * default.
    */
   files?:
     | Array<Readable | Buffer | string>
@@ -51,16 +50,14 @@ export type RequestOptions = {
   /** Type of request data, could be 'json'. If it's 'json', will auto set Content-Type: 'application/json' header. */
   contentType?: string;
   /**
-   * Type of response data. Could be text or json.
-   * If it's text or html, the callbacked data would be a String.
-   * If it's json, the data of callback would be a parsed JSON Object
-   * and will auto set Accept: 'application/json' header.
+   * Type of response data. Could be text or json. If it's text or html, the callbacked data would be a String. If it's
+   * json, the data of callback would be a parsed JSON Object and will auto set Accept: 'application/json' header.
    * Default is 'buffer'.
    */
   dataType?: 'text' | 'html' | 'json' | 'buffer' | 'stream';
   /**
-   * urllib default use URLSearchParams to stringify form data which don't support nested object,
-   * will use qs instead of URLSearchParams to support nested object by set this option to true.
+   * Urllib default use URLSearchParams to stringify form data which don't support nested object, will use qs instead of
+   * URLSearchParams to support nested object by set this option to true.
    */
   nestedQuerystring?: boolean;
   /**
@@ -85,27 +82,23 @@ export type RequestOptions = {
   /** Request headers. */
   headers?: IncomingHttpHeaders;
   /**
-   * Request timeout in milliseconds for connecting phase and response receiving phase.
-   * Defaults is `5000`, both are 5 seconds. You can use timeout: 5000 to tell urllib use same timeout on two phase or set them separately such as
+   * Request timeout in milliseconds for connecting phase and response receiving phase. Defaults is `5000`, both are 5
+   * seconds. You can use timeout: 5000 to tell urllib use same timeout on two phase or set them separately such as
    * timeout: [3000, 5000], which will set connecting timeout to 3s and response 5s.
    */
   timeout?: number | number[];
   /**
-   * Default is `4000`,  4 seconds - The timeout after which a socket without active requests will time out.
-   * Monitors time between activity on a connected socket.
-   * This value may be overridden by *keep-alive* hints from the server. See [MDN: HTTP - Headers - Keep-Alive directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive#directives) for more details.
+   * Default is `4000`, 4 seconds - The timeout after which a socket without active requests will time out. Monitors
+   * time between activity on a connected socket. This value may be overridden by _keep-alive_ hints from the server.
+   * See [MDN: HTTP - Headers - Keep-Alive
+   * directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive#directives) for more details.
    */
   keepAliveTimeout?: number;
-  /**
-   * username:password used in HTTP Basic Authorization.
-   * Alias to `headers.authorization = xxx`
-   **/
+  /** Username:password used in HTTP Basic Authorization. Alias to `headers.authorization = xxx` */
   auth?: string;
-  /**
-   * username:password used in HTTP Digest Authorization.
-   * */
+  /** Username:password used in HTTP Digest Authorization. */
   digestAuth?: string;
-  /** follow HTTP 3xx responses as redirects. defaults to true. */
+  /** Follow HTTP 3xx responses as redirects. defaults to true. */
   followRedirect?: boolean;
   /** The maximum number of redirects to follow, defaults to 10. */
   maxRedirects?: number;
@@ -118,28 +111,26 @@ export type RequestOptions = {
   /**
    * @deprecated
    * Alias to compressed
-   * */
+   */
   gzip?: boolean;
-  /**
-   * Enable timing or not, default is `true`.
-   * */
+  /** Enable timing or not, default is `true`. */
   timing?: boolean;
   /**
-   * Auto retry times on 5xx response, default is `0`. Don't work on streaming request
-   * It's not supported by using retry and writeStream, because the retry request can't stop the stream which is consuming.
-   **/
+   * Auto retry times on 5xx response, default is `0`. Don't work on streaming request It's not supported by using retry
+   * and writeStream, because the retry request can't stop the stream which is consuming.
+   */
   retry?: number;
   /** Wait a delay(ms) between retries */
   retryDelay?: number;
   /**
-   * Determine whether retry, a response object as the first argument.
-   * It will retry when status >= 500 by default. Request error is not included.
+   * Determine whether retry, a response object as the first argument. It will retry when status >= 500 by default.
+   * Request error is not included.
    */
   isRetry?: (response: HttpClientResponse) => boolean;
   /**
-   * Auto retry times on socket error, default is `1`. Don't work on streaming request
-   * It's not supported by using retry and writeStream, because the retry request can't stop the stream which is consuming.
-   **/
+   * Auto retry times on socket error, default is `1`. Don't work on streaming request It's not supported by using retry
+   * and writeStream, because the retry request can't stop the stream which is consuming.
+   */
   socketErrorRetry?: number;
   /** Default: `null` */
   opaque?: unknown;
@@ -148,13 +139,9 @@ export type RequestOptions = {
    * Maybe you should use opaque instead
    */
   ctx?: unknown;
-  /**
-   * request dispatcher, default is getGlobalDispatcher()
-   */
+  /** Request dispatcher, default is getGlobalDispatcher() */
   dispatcher?: Dispatcher;
-  /**
-   * unix domain socket file path
-   */
+  /** Unix domain socket file path */
   socketPath?: string | null;
   /** Whether the request should stablish a keep-alive or not. Default `false`, try to keep alive by default */
   reset?: boolean;

--- a/src/Response.ts
+++ b/src/Response.ts
@@ -22,9 +22,7 @@ export type SocketInfo = {
   connectPort?: string;
 };
 
-/**
- * https://eggjs.org/en/core/httpclient.html#timing-boolean
- */
+/** https://eggjs.org/en/core/httpclient.html#timing-boolean */
 export type Timing = {
   // socket assigned
   queuing: number;
@@ -47,9 +45,9 @@ export type RawResponseWithMeta = Readable & {
   statusCode: number;
   statusText: string;
   /**
-   * @alias statusText
    * @deprecated use `statusText` instead
-   **/
+   * @alias statusText
+   */
   statusMessage: string;
   headers: IncomingHttpHeaders;
   timing: Timing;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,8 @@ export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boo
 
 interface UrllibRequestOptions extends RequestOptions {
   /**
-   * If `true`, the server certificate is verified against the list of supplied CAs.
-   * An 'error' event is emitted if verification fails.
-   * Default: `true`
+   * If `true`, the server certificate is verified against the list of supplied CAs. An 'error' event is emitted if
+   * verification fails. Default: `true`
    */
   rejectUnauthorized?: boolean;
   /** Allow to use HTTP2 first. Default is `false` */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
       newlinesBetween: true,
       order: 'asc',
     },
+    jsdoc: {
+      preferCodeFences: true,
+    },
   },
   lint: {
     options: {


### PR DESCRIPTION
https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html#jsdoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted JSDoc comments across multiple files for improved clarity and consistency.

* **Chores**
  * Updated code formatting configuration to enforce consistent documentation block formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->