### PR TITLE
ci: test setup-vp PR #72 with sfw enabled

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
+        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
         with:
           node-version: '24'
           cache: true
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
+        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
         with:
           node-version: ${{ matrix.node }}
           cache: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,11 +18,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
         with:
           node-version: '24'
           cache: true
           run-install: true
+          sfw: true
 
       - name: Check
         run: vp run check
@@ -58,11 +59,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
         with:
           node-version: ${{ matrix.node }}
           cache: true
           run-install: true
+          sfw: true
 
       - name: Run tests
         run: vp run ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
+        uses: voidzero-dev/setup-vp@b6a100fe28076884691ad8f750d6601635fc1e2a # pr/72
         with:
           node-version: '24'
           cache: true
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
+        uses: voidzero-dev/setup-vp@b6a100fe28076884691ad8f750d6601635fc1e2a # pr/72
         with:
           node-version: ${{ matrix.node }}
           cache: true

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,11 +13,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
         with:
           node-version: 22
           cache: true
           run-install: true
+          sfw: true
 
       - name: Build
         run: vp run build

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
+        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
         with:
           node-version: 22
           cache: true

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
+        uses: voidzero-dev/setup-vp@b6a100fe28076884691ad8f750d6601635fc1e2a # pr/72
         with:
           node-version: 22
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
+        uses: voidzero-dev/setup-vp@b6a100fe28076884691ad8f750d6601635fc1e2a # pr/72
         with:
           node-version: '22'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
+        uses: voidzero-dev/setup-vp@e6024b3b5ea5b627a4af5506224c1bb1da826712 # pr/72
         with:
           node-version: '22'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@f5f2b16de3f7b95fa5ce9398c03e7b55bd6a4529 # pr/72
         with:
           node-version: '22'
           cache: true
           run-install: true
+          sfw: true
 
       - name: Verify version matches tag
         run: |


### PR DESCRIPTION
## Summary

- Pin `voidzero-dev/setup-vp` to the PR #72 commit (`f5f2b16`) across all workflows (`nodejs.yml`, `pkg.pr.new.yml`, `release.yml`)
- Enable the new `sfw: true` input to wrap `vp install` with Socket Firewall Free

Per the PR's last commit, sfw only activates on Linux. macOS/Windows runners in the test matrix fall back to plain `vp install` with a warning, which is expected.

Refs: https://github.com/voidzero-dev/setup-vp/pull/72

## Test plan

- [ ] CI green on Linux (sfw active)
- [ ] CI green on macOS/Windows (sfw warns and falls back)
- [ ] Revert to `voidzero-dev/setup-vp@v1` (without `sfw`) once PR #72 is merged and released