### PR TITLE
chore: move pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,17 +111,5 @@
   "engines": {
     "node": ">= 22.0.0"
   },
-  "packageManager": "pnpm@11.3.0",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.22",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.22"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ]
-    }
-  }
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: npm:@voidzero-dev/vite-plus-core@^0.1.22
+  vitest: npm:@voidzero-dev/vite-plus-test@^0.1.22
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,10 @@ minimumReleaseAgeExclude:
   - '@voidzero-dev/vite-plus-win32-arm64-msvc'
   - '@voidzero-dev/vite-plus-win32-x64-msvc'
   - vite-plus
+overrides:
+  vite: 'npm:@voidzero-dev/vite-plus-core@^0.1.22'
+  vitest: 'npm:@voidzero-dev/vite-plus-test@^0.1.22'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest


### PR DESCRIPTION
## Summary

- Move `pnpm.overrides` and `pnpm.peerDependencyRules` out of `package.json` and into `pnpm-workspace.yaml` as top-level `overrides` and `peerDependencyRules` keys.
- pnpm no longer reads the `pnpm` field in `package.json` and emits a warning on install:

  ```
  [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides", "pnpm.peerDependencyRules". See https://pnpm.io/settings for the new home of each setting.
  ```

## Test plan

- [x] `vp install` no longer emits the deprecation warning
- [x] `vitest` still resolves to `@voidzero-dev/vite-plus-test` via the override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to consolidate override and peer dependency settings, improving project organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/node-modules/urllib/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->