### PR TITLE
ci: pin setup-vp to cache reserve-race warning fix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@b250484f0d7da679524e2f30c1330935444328f9 # fix: silence benign cache reserve-race warnings (voidzero-dev/setup-vp#75); revert to @v1 after release
+        uses: voidzero-dev/setup-vp@6cb180a2f884264930ebcd4169f924720120c4b4 # fix: silence benign cache reserve-race warnings (voidzero-dev/setup-vp#75); revert to @v1 after release
         with:
           node-version: '24'
           cache: true
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@b250484f0d7da679524e2f30c1330935444328f9 # fix: silence benign cache reserve-race warnings (voidzero-dev/setup-vp#75); revert to @v1 after release
+        uses: voidzero-dev/setup-vp@6cb180a2f884264930ebcd4169f924720120c4b4 # fix: silence benign cache reserve-race warnings (voidzero-dev/setup-vp#75); revert to @v1 after release
         with:
           node-version: ${{ matrix.node }}
           cache: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@b250484f0d7da679524e2f30c1330935444328f9 # fix: silence benign cache reserve-race warnings (voidzero-dev/setup-vp#75); revert to @v1 after release
         with:
           node-version: '24'
           cache: true
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@b250484f0d7da679524e2f30c1330935444328f9 # fix: silence benign cache reserve-race warnings (voidzero-dev/setup-vp#75); revert to @v1 after release
         with:
           node-version: ${{ matrix.node }}
           cache: true


### PR DESCRIPTION
## What

Pins `voidzero-dev/setup-vp` in `nodejs.yml` (both the `check` and matrix `test` jobs) to the fix commit [`b250484`](https://github.com/voidzero-dev/setup-vp/commit/b250484f0d7da679524e2f30c1330935444328f9) from voidzero-dev/setup-vp#75.

## Why

Our CI was producing harmless-but-noisy warning annotations from setup-vp's cache step, e.g. in [run #26621172939](https://github.com/node-modules/urllib/actions/runs/26621172939):

```
! Cache save failed or was skipped.
! Failed to save: Unable to reserve cache with key vite-plus-Linux-x64-pnpm-…, another job may be creating this cache.
```

**Root cause:** setup-vp's cache key is `vite-plus-{OS}-{arch}-{lockfile}-{hash}` and intentionally excludes the Node version (the package-manager store is Node-version-independent). Our matrix runs 3 Node versions per OS, so those jobs share one key and race to save it in the post step. GitHub lets only one job reserve a key; the losers get a benign `-1`, which setup-vp was surfacing as a warning annotation. Caching itself always worked.

setup-vp#75 demotes that benign path from `warning` to `info`. This PR's CI run should come back **without** the `Cache save failed or was skipped.` annotations.

## Note

This is a **temporary SHA pin** for verification. Once setup-vp#75 is merged and the `v1` tag is re-cut, revert these two lines back to `voidzero-dev/setup-vp@v1` (which will then carry the fix automatically). The `release.yml` and `pkg.pr.new.yml` workflows are left on `@v1` (single-job, no matrix → no warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a CI action to a specific commit SHA in the check and test workflow jobs (including matrix runs) to stabilize CI behavior; change is marked temporary and will be reverted after release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/node-modules/urllib/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->