### PR TITLE
fix: do not forward credential headers on cross-origin redirect

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -184,6 +184,12 @@ const RedirectStatusCodes = [
   308, // Permanent Redirect
 ];
 
+// Credential-bearing headers that must not be forwarded across an origin
+// boundary when following a redirect, to avoid leaking them to a third party.
+// Matches the WHATWG Fetch spec and undici's RedirectHandler.
+// https://fetch.spec.whatwg.org/#http-redirect-fetch
+const CrossOriginSensitiveHeaders = new Set(['authorization', 'cookie', 'proxy-authorization']);
+
 export class HttpClient extends EventEmitter {
   #defaultArgs?: RequestOptions;
   #dispatcher?: Dispatcher;
@@ -647,6 +653,22 @@ export class HttpClient extends EventEmitter {
           const nextUrl = new URL(res.headers.location, requestUrl.href);
           // Ensure the response is consumed
           await response.body.arrayBuffer();
+          let redirectOptions = options;
+          // Do not forward credential-bearing headers to a different origin.
+          if (nextUrl.origin !== requestUrl.origin) {
+            const cleanedHeaders: IncomingHttpHeaders = {};
+            if (options?.headers) {
+              for (const name in options.headers) {
+                if (!CrossOriginSensitiveHeaders.has(name.toLowerCase())) {
+                  cleanedHeaders[name] = options.headers[name];
+                }
+              }
+            }
+            // Clone so the caller's options object is never mutated, and drop
+            // credentials so they are not re-applied on the new origin,
+            // including Basic/digest auth inherited from the client's defaultArgs.
+            redirectOptions = { ...options, headers: cleanedHeaders, auth: undefined, digestAuth: undefined };
+          }
           debug(
             'Request#%d got response, status: %s, headers: %j, timing: %j, redirect to %s',
             requestId,
@@ -655,7 +677,7 @@ export class HttpClient extends EventEmitter {
             res.timing,
             nextUrl.href,
           );
-          return await this.#requestInternal(nextUrl.href, options, requestContext);
+          return await this.#requestInternal(nextUrl.href, redirectOptions, requestContext);
         }
       }
 

--- a/test/fixtures/server.ts
+++ b/test/fixtures/server.ts
@@ -244,6 +244,13 @@ export async function startServer(options?: {
       res.setHeader('Location', 'http://localhost/');
       return res.end('Redirect to http://localhost/');
     }
+    // redirect to an arbitrary absolute url, e.g. a different origin
+    if (pathname === '/redirect-to') {
+      const target = urlObject.searchParams.get('url')!;
+      res.statusCode = parseInt(urlObject.searchParams.get('status') ?? '302');
+      res.setHeader('Location', target);
+      return res.end(`Redirect to ${target}`);
+    }
 
     if (req.url === '/304-with-gzip') {
       res.setHeader('Content-Encoding', 'gzip');

--- a/test/options.followRedirect.crossOrigin.test.ts
+++ b/test/options.followRedirect.crossOrigin.test.ts
@@ -1,0 +1,133 @@
+import { strict as assert } from 'node:assert';
+
+import { describe, it, beforeAll, afterAll } from 'vite-plus/test';
+
+import urllib, { HttpClient } from '../src/index.js';
+import { startServer } from './fixtures/server.js';
+
+// On a cross-origin redirect, credential-bearing request headers
+// (Authorization, Cookie, Proxy-Authorization) must NOT be forwarded
+// to the new origin. Same-origin redirects should keep them.
+describe('options.followRedirect.crossOrigin.test.ts', () => {
+  let closeA: any;
+  let closeB: any;
+  let urlA: string;
+  let urlB: string;
+
+  beforeAll(async () => {
+    const a = await startServer();
+    const b = await startServer();
+    closeA = a.closeServer;
+    closeB = b.closeServer;
+    urlA = a.url;
+    urlB = b.url;
+  });
+
+  afterAll(async () => {
+    await closeA();
+    await closeB();
+  });
+
+  const credentialHeaders = {
+    Authorization: 'Bearer LIVE-AUTH',
+    Cookie: 'session=LIVE-COOKIE',
+    'Proxy-Authorization': 'Bearer proxy-LIVE',
+  };
+
+  // `from` redirects (302) to absolute url `to`
+  const buildRedirectUrl = (from: string, to: string) => `${from}redirect-to?url=${encodeURIComponent(to)}`;
+  // headers the final target actually received, echoed back via x-request-headers
+  const receivedHeaders = (response: { headers: Record<string, string | string[] | undefined> }) =>
+    JSON.parse(response.headers['x-request-headers'] as string);
+
+  it('should NOT forward credential headers on cross-origin redirect', async () => {
+    // server A redirects to a DIFFERENT origin (server B, different port)
+    const response = await urllib.request(buildRedirectUrl(urlA, `${urlB}hello/json`), {
+      dataType: 'json',
+      headers: { ...credentialHeaders },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.requestUrls.length, 2);
+    const received = receivedHeaders(response);
+    assert.equal(received.authorization, undefined, 'authorization must be stripped cross-origin');
+    assert.equal(received.cookie, undefined, 'cookie must be stripped cross-origin');
+    assert.equal(received['proxy-authorization'], undefined, 'proxy-authorization must be stripped cross-origin');
+  });
+
+  it('should keep credential headers on same-origin redirect', async () => {
+    const response = await urllib.request(buildRedirectUrl(urlA, `${urlA}hello/json`), {
+      dataType: 'json',
+      headers: { ...credentialHeaders },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.requestUrls.length, 2);
+    const received = receivedHeaders(response);
+    assert.equal(received.authorization, 'Bearer LIVE-AUTH');
+    assert.equal(received.cookie, 'session=LIVE-COOKIE');
+    assert.equal(received['proxy-authorization'], 'Bearer proxy-LIVE');
+  });
+
+  it('should NOT forward credential headers when redirected cross-origin and back to the original origin', async () => {
+    // A -> B (cross-origin) -> A (back to original origin)
+    // Once stripped at the boundary, credentials must stay stripped.
+    const viaB = buildRedirectUrl(urlB, `${urlA}hello/json`);
+    const response = await urllib.request(buildRedirectUrl(urlA, viaB), {
+      dataType: 'json',
+      headers: { ...credentialHeaders },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.requestUrls.length, 3);
+    const received = receivedHeaders(response);
+    assert.equal(received.authorization, undefined);
+    assert.equal(received.cookie, undefined);
+    assert.equal(received['proxy-authorization'], undefined);
+  });
+
+  it('should NOT re-inject Basic auth (options.auth) on cross-origin redirect', async () => {
+    const response = await urllib.request(buildRedirectUrl(urlA, `${urlB}hello/json`), {
+      dataType: 'json',
+      auth: 'user:passwd',
+    });
+    assert.equal(response.status, 200);
+    const received = receivedHeaders(response);
+    assert.equal(received.authorization, undefined, 'Basic auth must not be sent cross-origin');
+  });
+
+  it('should keep Basic auth (options.auth) on same-origin redirect', async () => {
+    const response = await urllib.request(buildRedirectUrl(urlA, `${urlA}hello/json`), {
+      dataType: 'json',
+      auth: 'user:passwd',
+    });
+    assert.equal(response.status, 200);
+    const received = receivedHeaders(response);
+    assert.equal(received.authorization, `Basic ${Buffer.from('user:passwd').toString('base64')}`);
+  });
+
+  it('should NOT re-inject defaultArgs credentials cross-origin when called without per-call options', async () => {
+    // defaultArgs.auth + request(url) with no options object: the strip path
+    // must still run, otherwise Basic auth is re-applied on the new origin.
+    const client = new HttpClient({ defaultArgs: { auth: 'user:passwd' } });
+    const response = await client.request(buildRedirectUrl(urlA, `${urlB}hello/json`));
+    assert.equal(response.status, 200);
+    const received = receivedHeaders(response);
+    assert.equal(received.authorization, undefined, 'defaultArgs Basic auth must not be sent cross-origin');
+  });
+
+  it('should keep defaultArgs credentials on same-origin redirect when called without per-call options', async () => {
+    const client = new HttpClient({ defaultArgs: { auth: 'user:passwd' } });
+    const response = await client.request(buildRedirectUrl(urlA, `${urlA}hello/json`));
+    assert.equal(response.status, 200);
+    const received = receivedHeaders(response);
+    assert.equal(received.authorization, `Basic ${Buffer.from('user:passwd').toString('base64')}`);
+  });
+
+  it('should not mutate the caller-supplied options.headers on cross-origin redirect', async () => {
+    const headers = { ...credentialHeaders };
+    await urllib.request(buildRedirectUrl(urlA, `${urlB}hello/json`), {
+      dataType: 'json',
+      headers,
+    });
+    // the original object the caller passed must be untouched
+    assert.deepEqual(headers, credentialHeaders);
+  });
+});


### PR DESCRIPTION
## Problem

When following a redirect to a different origin, urllib reused the caller's `options` verbatim, re-sending `Authorization`, `Cookie`, and `Proxy-Authorization` (and re-injecting Basic/digest auth from `auth` or the client's `defaultArgs`) to the new origin.

## Fix

When `nextUrl.origin !== requestUrl.origin`, recurse with a cloned `options` that drops those credential headers (case-insensitive) and clears `auth`/`digestAuth`, matching the WHATWG Fetch spec and undici's `RedirectHandler`. Same-origin redirects are unchanged and the caller's `options` object is never mutated.

## Tests

New `test/options.followRedirect.crossOrigin.test.ts`: cross-origin strip, same-origin preserve, cross-then-back-to-origin, `auth`/`defaultArgs` not re-injected cross-origin, and options-not-mutated.