### PR TITLE
feat: upgrade to undici@8

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "vite-plus": {
-      "command": "npx",
-      "args": ["vp", "mcp"]
-    }
-  }
-}

--- a/.claude/skills/vite-plus
+++ b/.claude/skills/vite-plus
@@ -1,1 +1,0 @@
-../../node_modules/vite-plus/skills/vite-plus

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        node: ['22', '24', '25']
+        node: ['22', '24', '26']
 
     name: Test (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# Patch coverage stays strict (new/changed lines must be covered).
+# Project coverage tolerates small fluctuations from external-network tests
+# and undici behaviour changes (e.g. an error branch reachable only on a
+# different protocol path).
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 0%

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mime-types": "^2.1.35",
     "qs": "^6.15.0",
     "type-fest": "^4.41.0",
-    "undici": "^7.24.0",
+    "undici": "^8.4.1",
     "ylru": "^2.0.0"
   },
   "devDependencies": {
@@ -110,7 +110,7 @@
     }
   },
   "engines": {
-    "node": ">= 22.0.0"
+    "node": ">= 22.19.0"
   },
   "packageManager": "pnpm@11.6.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     dependencies:
       form-data:
         specifier: ^4.0.5
-        version: 4.0.5
+        version: 4.0.6
       formstream:
         specifier: ^1.5.2
         version: 1.5.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^4.41.0
         version: 4.41.0
       undici:
-        specifier: ^7.24.0
-        version: 7.27.2
+        specifier: ^8.4.1
+        version: 8.4.1
       ylru:
         specifier: ^2.0.0
         version: 2.0.0
@@ -917,8 +917,8 @@ packages:
     resolution: {integrity: sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==}
     engines: {node: '>=16'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formstream@1.5.2:
@@ -971,8 +971,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   highlight.js@10.7.3:
@@ -1452,9 +1452,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
-    engines: {node: '>=20.18.1'}
+  undici@8.4.1:
+    resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+    engines: {node: '>=22.19.0'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -2073,7 +2073,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   escalade@3.2.0: {}
 
@@ -2093,12 +2093,12 @@ snapshots:
     dependencies:
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formstream@1.5.2:
@@ -2127,7 +2127,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -2153,7 +2153,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -2607,7 +2607,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.27.2: {}
+  undici@8.4.1: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/src/HttpAgent.ts
+++ b/src/HttpAgent.ts
@@ -66,7 +66,10 @@ export class HttpAgent extends BaseAgent {
     };
     super({
       ...baseOpts,
-      connect: { ...options.connect, lookup: lookupFunction, allowH2: options.allowH2 },
+      // Keep allowH2 at the top level only. undici builds the connector as
+      // `buildConnector({ allowH2, ...connect })`, so an allowH2 inside `connect`
+      // would shadow the top-level/per-request value and defeat `allowH2: false`.
+      connect: { ...options.connect, lookup: lookupFunction },
     });
     this.#checkAddress = options.checkAddress;
   }

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -187,25 +187,17 @@ export function normalizePoolStatsKey(key: unknown): string {
 }
 
 // When both an HTTP/2 and an http1-only pool exist for the same origin, sum
-// their stats so a single origin entry reflects every client.
-export function mergePoolStat(existing: PoolStat | undefined, stats: PoolStat): PoolStat {
-  if (!existing) {
-    return {
-      connected: stats.connected,
-      free: stats.free,
-      pending: stats.pending,
-      queued: stats.queued,
-      running: stats.running,
-      size: stats.size,
-    };
-  }
+// their stats so a single origin entry reflects every client. undici ClientStats
+// (Agent with connections: 1) omit free/queued, so treat absent counters as 0.
+export function mergePoolStat(existing: PoolStat | undefined, stats: Partial<PoolStat>): PoolStat {
+  const base = existing ?? { connected: 0, free: 0, pending: 0, queued: 0, running: 0, size: 0 };
   return {
-    connected: existing.connected + stats.connected,
-    free: existing.free + stats.free,
-    pending: existing.pending + stats.pending,
-    queued: existing.queued + stats.queued,
-    running: existing.running + stats.running,
-    size: existing.size + stats.size,
+    connected: base.connected + (stats.connected ?? 0),
+    free: base.free + (stats.free ?? 0),
+    pending: base.pending + (stats.pending ?? 0),
+    queued: base.queued + (stats.queued ?? 0),
+    running: base.running + (stats.running ?? 0),
+    size: base.size + (stats.size ?? 0),
   };
 }
 

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -74,7 +74,7 @@ const debug = debuglog('urllib:HttpClient');
 
 export type ClientOptions = {
   defaultArgs?: RequestOptions;
-  /** Allow to use HTTP2 first. Default is `false` */
+  /** Allow negotiating HTTP/2 with capable servers via ALPN. Since undici@8 this is enabled by default. */
   allowH2?: boolean;
   /** Custom DNS lookup function, default is `dns.lookup`. */
   lookup?: LookupFunction;

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -184,8 +184,7 @@ export function normalizePoolStatsKey(key: unknown): string {
   if (typeof key !== 'string') {
     return String(key);
   }
-  const index = key.indexOf(HTTP1_ONLY_POOL_KEY_SUFFIX);
-  return index === -1 ? key : key.slice(0, index);
+  return key.endsWith(HTTP1_ONLY_POOL_KEY_SUFFIX) ? key.slice(0, -HTTP1_ONLY_POOL_KEY_SUFFIX.length) : key;
 }
 
 // When both an HTTP/2 and an http1-only pool exist for the same origin, sum

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -175,14 +175,16 @@ export interface PoolStat {
   size: number;
 }
 
-// undici@8 keys http1-only pools (allowH2: false) as `${origin}#http1-only`;
-// expose them under their plain origin so callers can look up stats by URL.
+// undici@8 keys HTTP/1.1-only pools (dispatched with allowH2: false) by suffixing the origin.
+const HTTP1_ONLY_POOL_KEY_SUFFIX = '#http1-only';
+
+// Expose http1-only pools under their plain origin so callers can look up stats by URL.
 // MockAgent may use RegExp/function origin matchers, so keys are not always strings.
 export function normalizePoolStatsKey(key: unknown): string {
   if (typeof key !== 'string') {
     return String(key);
   }
-  const index = key.indexOf('#http1-only');
+  const index = key.indexOf(HTTP1_ONLY_POOL_KEY_SUFFIX);
   return index === -1 ? key : key.slice(0, index);
 }
 
@@ -190,15 +192,34 @@ export function normalizePoolStatsKey(key: unknown): string {
 // their stats so a single origin entry reflects every client. undici ClientStats
 // (Agent with connections: 1) omit free/queued, so treat absent counters as 0.
 export function mergePoolStat(existing: PoolStat | undefined, stats: Partial<PoolStat>): PoolStat {
-  const base = existing ?? { connected: 0, free: 0, pending: 0, queued: 0, running: 0, size: 0 };
   return {
-    connected: base.connected + (stats.connected ?? 0),
-    free: base.free + (stats.free ?? 0),
-    pending: base.pending + (stats.pending ?? 0),
-    queued: base.queued + (stats.queued ?? 0),
-    running: base.running + (stats.running ?? 0),
-    size: base.size + (stats.size ?? 0),
+    connected: (existing?.connected ?? 0) + (stats.connected ?? 0),
+    free: (existing?.free ?? 0) + (stats.free ?? 0),
+    pending: (existing?.pending ?? 0) + (stats.pending ?? 0),
+    queued: (existing?.queued ?? 0) + (stats.queued ?? 0),
+    running: (existing?.running ?? 0) + (stats.running ?? 0),
+    size: (existing?.size ?? 0) + (stats.size ?? 0),
   };
+}
+
+// Collect undici pool stats for a dispatcher, collapsing undici@8's http1-only
+// pools back onto their origin so HttpClient and FetchFactory share one implementation.
+export function buildPoolStats(agent: Dispatcher): Record<string, PoolStat> {
+  // origin => Pool Instance
+  const clients: Map<string, WeakRef<Pool>> | undefined = Reflect.get(agent, undiciSymbols.kClients);
+  const poolStatsMap: Record<string, PoolStat> = {};
+  if (!clients) {
+    return poolStatsMap;
+  }
+  for (const [key, ref] of clients) {
+    const pool = (typeof ref.deref === 'function' ? ref.deref() : ref) as unknown as Pool & { dispatcher: Pool };
+    // NOTE: pool become to { dispatcher: Pool } in undici@v7
+    const stats = pool?.stats ?? pool?.dispatcher?.stats;
+    if (!stats) continue;
+    const origin = normalizePoolStatsKey(key);
+    poolStatsMap[origin] = mergePoolStat(poolStatsMap[origin], stats);
+  }
+  return poolStatsMap;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
@@ -258,25 +279,7 @@ export class HttpClient extends EventEmitter {
   }
 
   getDispatcherPoolStats(): Record<string, PoolStat> {
-    const agent = this.getDispatcher();
-    // origin => Pool Instance
-    const clients: Map<string, WeakRef<Pool>> | undefined = Reflect.get(agent, undiciSymbols.kClients);
-    const poolStatsMap: Record<string, PoolStat> = {};
-    if (!clients) {
-      return poolStatsMap;
-    }
-    for (const [key, ref] of clients) {
-      const pool = (typeof ref.deref === 'function' ? ref.deref() : ref) as unknown as Pool & { dispatcher: Pool };
-      // NOTE: pool become to { dispatcher: Pool } in undici@v7
-      const stats = pool?.stats ?? pool?.dispatcher?.stats;
-      if (!stats) continue;
-
-      // undici@8 keys http1-only pools (allowH2: false) as `${origin}#http1-only`,
-      // expose them by their origin so callers can look up stats by URL.
-      const origin = normalizePoolStatsKey(key);
-      poolStatsMap[origin] = mergePoolStat(poolStatsMap[origin], stats);
-    }
-    return poolStatsMap;
+    return buildPoolStats(this.getDispatcher());
   }
 
   async request<T = any>(url: RequestURL, options?: RequestOptions): Promise<HttpClientResponse<T>> {
@@ -480,7 +483,11 @@ export class HttpClient extends EventEmitter {
         // as `${origin}#http1-only` and would miss interceptors registered on
         // the plain origin (protocol negotiation is moot when mocking anyway).
         const activeDispatcher = requestOptions.dispatcher ?? getGlobalDispatcher();
-        if (!(activeDispatcher instanceof MockAgent)) {
+        // `instanceof` misses a MockAgent from a duplicate undici install, so also
+        // match by constructor name as a cheap cross-realm fallback.
+        const isMockAgent =
+          activeDispatcher instanceof MockAgent || activeDispatcher?.constructor?.name === 'MockAgent';
+        if (!isMockAgent) {
           requestOptions.allowH2 = allowH2;
         }
       }

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -38,7 +38,11 @@ import { parseJSON, digestAuthHeader, globalId, performanceTime, isReadable, upd
 type Exists<T> = T extends undefined ? never : T;
 type UndiciRequestOption = Exists<Parameters<typeof undiciRequest>[1]>;
 type PropertyShouldBe<T, K extends keyof T, V> = Omit<T, K> & { [P in K]: V };
-type IUndiciRequestOption = PropertyShouldBe<UndiciRequestOption, 'headers', IncomingHttpHeaders>;
+// undici reads `allowH2` per dispatch (Agent picks an http1-only pool when false),
+// but it is not part of the public request options type, so add it explicitly.
+type IUndiciRequestOption = PropertyShouldBe<UndiciRequestOption, 'headers', IncomingHttpHeaders> & {
+  allowH2?: boolean;
+};
 
 export const PROTO_RE: RegExp = /^https?:\/\//i;
 
@@ -171,6 +175,36 @@ export interface PoolStat {
   size: number;
 }
 
+// undici@8 keys http1-only pools (allowH2: false) as `${origin}#http1-only`;
+// expose them under their plain origin so callers can look up stats by URL.
+export function normalizePoolStatsKey(key: string): string {
+  const index = key.indexOf('#http1-only');
+  return index === -1 ? key : key.slice(0, index);
+}
+
+// When both an HTTP/2 and an http1-only pool exist for the same origin, sum
+// their stats so a single origin entry reflects every client.
+export function mergePoolStat(existing: PoolStat | undefined, stats: PoolStat): PoolStat {
+  if (!existing) {
+    return {
+      connected: stats.connected,
+      free: stats.free,
+      pending: stats.pending,
+      queued: stats.queued,
+      running: stats.running,
+      size: stats.size,
+    };
+  }
+  return {
+    connected: existing.connected + stats.connected,
+    free: existing.free + stats.free,
+    pending: existing.pending + stats.pending,
+    queued: existing.queued + stats.queued,
+    running: existing.running + stats.running,
+    size: existing.size + stats.size,
+  };
+}
+
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
 const RedirectStatusCodes = [
   301, // Moved Permanently
@@ -189,10 +223,14 @@ const CrossOriginSensitiveHeaders = new Set(['authorization', 'cookie', 'proxy-a
 export class HttpClient extends EventEmitter {
   #defaultArgs?: RequestOptions;
   #dispatcher?: Dispatcher;
+  #allowH2?: boolean;
 
   constructor(clientOptions?: ClientOptions) {
     super();
     this.#defaultArgs = clientOptions?.defaultArgs;
+    // Remember the client-level protocol preference so it can be applied per
+    // request (mainly for `allowH2: false`, which has no dedicated agent).
+    this.#allowH2 = clientOptions?.allowH2;
     if (clientOptions?.lookup || clientOptions?.checkAddress) {
       this.#dispatcher = new HttpAgent({
         lookup: clientOptions.lookup,
@@ -205,9 +243,9 @@ export class HttpClient extends EventEmitter {
         connect: clientOptions.connect,
         allowH2: clientOptions.allowH2,
       });
-    } else if (clientOptions?.allowH2 !== undefined) {
-      // Pin the protocol when allowH2 is set explicitly: `true` enables HTTP/2,
-      // `false` forces HTTP/1.1 instead of following undici@8's HTTP/2 default.
+    } else if (clientOptions?.allowH2) {
+      // Support HTTP/2 with a dedicated agent. `allowH2: false` is handled
+      // per request instead, so it does not bypass the active dispatcher.
       this.#dispatcher = new Agent({
         allowH2: clientOptions.allowH2,
       });
@@ -237,14 +275,10 @@ export class HttpClient extends EventEmitter {
       const stats = pool?.stats ?? pool?.dispatcher?.stats;
       if (!stats) continue;
 
-      poolStatsMap[key] = {
-        connected: stats.connected,
-        free: stats.free,
-        pending: stats.pending,
-        queued: stats.queued,
-        running: stats.running,
-        size: stats.size,
-      } satisfies PoolStat;
+      // undici@8 keys http1-only pools (allowH2: false) as `${origin}#http1-only`,
+      // expose them by their origin so callers can look up stats by URL.
+      const origin = normalizePoolStatsKey(key);
+      poolStatsMap[origin] = mergePoolStat(poolStatsMap[origin], stats);
     }
     return poolStatsMap;
   }
@@ -442,6 +476,13 @@ export class HttpClient extends EventEmitter {
         signal: args.signal,
         reset: false,
       };
+      const allowH2 = args.allowH2 ?? this.#allowH2;
+      if (typeof allowH2 === 'boolean') {
+        // Apply the protocol preference per request so the active dispatcher
+        // (global, proxy, ...) is honored instead of being bypassed by a
+        // dedicated HTTP/1.1-only agent.
+        requestOptions.allowH2 = allowH2;
+      }
       if (typeof args.highWaterMark === 'number') {
         requestOptions.highWaterMark = args.highWaterMark;
       }

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -222,6 +222,12 @@ export function buildPoolStats(agent: Dispatcher): Record<string, PoolStat> {
   return poolStatsMap;
 }
 
+// `instanceof` misses a MockAgent from a duplicate undici install, so also match
+// by constructor name as a cheap cross-realm fallback.
+function isMockAgent(dispatcher: Dispatcher | undefined): boolean {
+  return dispatcher instanceof MockAgent || dispatcher?.constructor?.name === 'MockAgent';
+}
+
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
 const RedirectStatusCodes = [
   301, // Moved Permanently
@@ -475,21 +481,14 @@ export class HttpClient extends EventEmitter {
         signal: args.signal,
         reset: false,
       };
+      // Apply the protocol preference per request so the active dispatcher (global,
+      // proxy, ...) is honored instead of being bypassed by a dedicated HTTP/1.1-only
+      // agent. Skip it for MockAgent: it keys clients as `${origin}#http1-only` and
+      // would miss interceptors registered on the plain origin (protocol negotiation
+      // is moot when mocking anyway).
       const allowH2 = args.allowH2 ?? this.#allowH2;
-      if (typeof allowH2 === 'boolean') {
-        // Apply the protocol preference per request so the active dispatcher
-        // (global, proxy, ...) is honored instead of being bypassed by a
-        // dedicated HTTP/1.1-only agent. Skip it for MockAgent: it keys clients
-        // as `${origin}#http1-only` and would miss interceptors registered on
-        // the plain origin (protocol negotiation is moot when mocking anyway).
-        const activeDispatcher = requestOptions.dispatcher ?? getGlobalDispatcher();
-        // `instanceof` misses a MockAgent from a duplicate undici install, so also
-        // match by constructor name as a cheap cross-realm fallback.
-        const isMockAgent =
-          activeDispatcher instanceof MockAgent || activeDispatcher?.constructor?.name === 'MockAgent';
-        if (!isMockAgent) {
-          requestOptions.allowH2 = allowH2;
-        }
+      if (typeof allowH2 === 'boolean' && !isMockAgent(requestOptions.dispatcher ?? getGlobalDispatcher())) {
+        requestOptions.allowH2 = allowH2;
       }
       if (typeof args.highWaterMark === 'number') {
         requestOptions.highWaterMark = args.highWaterMark;

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -74,7 +74,7 @@ const debug = debuglog('urllib:HttpClient');
 
 export type ClientOptions = {
   defaultArgs?: RequestOptions;
-  /** Allow negotiating HTTP/2 with capable servers via ALPN. Since undici@8 this is enabled by default. */
+  /** Negotiate HTTP/2 with capable servers via ALPN. Enabled by default since undici@8; set `false` to force HTTP/1.1. */
   allowH2?: boolean;
   /** Custom DNS lookup function, default is `dns.lookup`. */
   lookup?: LookupFunction;
@@ -205,8 +205,9 @@ export class HttpClient extends EventEmitter {
         connect: clientOptions.connect,
         allowH2: clientOptions.allowH2,
       });
-    } else if (clientOptions?.allowH2) {
-      // Support HTTP2
+    } else if (clientOptions?.allowH2 !== undefined) {
+      // Pin the protocol when allowH2 is set explicitly: `true` enables HTTP/2,
+      // `false` forces HTTP/1.1 instead of following undici@8's HTTP/2 default.
       this.#dispatcher = new Agent({
         allowH2: clientOptions.allowH2,
       });

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -18,7 +18,7 @@ import { createGunzip, createBrotliDecompress, gunzipSync, brotliDecompressSync 
 import FormStream from 'formstream';
 import mime from 'mime-types';
 import qs from 'qs';
-import { request as undiciRequest, Dispatcher, Agent, getGlobalDispatcher, Pool } from 'undici';
+import { request as undiciRequest, Dispatcher, Agent, getGlobalDispatcher, MockAgent, Pool } from 'undici';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import undiciSymbols from 'undici/lib/core/symbols.js';
@@ -177,7 +177,11 @@ export interface PoolStat {
 
 // undici@8 keys http1-only pools (allowH2: false) as `${origin}#http1-only`;
 // expose them under their plain origin so callers can look up stats by URL.
-export function normalizePoolStatsKey(key: string): string {
+// MockAgent may use RegExp/function origin matchers, so keys are not always strings.
+export function normalizePoolStatsKey(key: unknown): string {
+  if (typeof key !== 'string') {
+    return String(key);
+  }
   const index = key.indexOf('#http1-only');
   return index === -1 ? key : key.slice(0, index);
 }
@@ -480,8 +484,13 @@ export class HttpClient extends EventEmitter {
       if (typeof allowH2 === 'boolean') {
         // Apply the protocol preference per request so the active dispatcher
         // (global, proxy, ...) is honored instead of being bypassed by a
-        // dedicated HTTP/1.1-only agent.
-        requestOptions.allowH2 = allowH2;
+        // dedicated HTTP/1.1-only agent. Skip it for MockAgent: it keys clients
+        // as `${origin}#http1-only` and would miss interceptors registered on
+        // the plain origin (protocol negotiation is moot when mocking anyway).
+        const activeDispatcher = requestOptions.dispatcher ?? getGlobalDispatcher();
+        if (!(activeDispatcher instanceof MockAgent)) {
+          requestOptions.allowH2 = allowH2;
+        }
       }
       if (typeof args.highWaterMark === 'number') {
         requestOptions.highWaterMark = args.highWaterMark;

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -144,6 +144,11 @@ export type RequestOptions = {
   /**
    * Negotiate HTTP/2 with capable servers via ALPN. Enabled by default since undici@8; set `false` to force HTTP/1.1
    * for this request without bypassing the active dispatcher.
+   *
+   * `allowH2: false` is applied per request and is honored by Agent-based dispatchers (the default global agent and
+   * `ProxyAgent`). It cannot downgrade a raw `Pool`/`Client` passed as `dispatcher`, which builds its connector at
+   * construction time, construct those with `allowH2: false` instead. It is also not applied to `MockAgent` (protocol
+   * negotiation is moot when mocking), so mock passthrough to the real network follows that agent's own default.
    */
   allowH2?: boolean;
   /** Unix domain socket file path */

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -14,7 +14,7 @@ export type RequestURL = string | URL;
 export type FixJSONCtlCharsHandler = (data: string) => string;
 export type FixJSONCtlChars = boolean | FixJSONCtlCharsHandler;
 
-type AbortSignal = unknown;
+type AbortSignal = globalThis.AbortSignal;
 
 export type RequestOptions = {
   /** Request method, defaults to GET. Could be GET, POST, DELETE or PUT. Alias 'type'. */

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -14,8 +14,6 @@ export type RequestURL = string | URL;
 export type FixJSONCtlCharsHandler = (data: string) => string;
 export type FixJSONCtlChars = boolean | FixJSONCtlCharsHandler;
 
-type AbortSignal = globalThis.AbortSignal;
-
 export type RequestOptions = {
   /** Request method, defaults to GET. Could be GET, POST, DELETE or PUT. Alias 'type'. */
   method?: HttpMethod | Lowercase<HttpMethod>;
@@ -157,7 +155,7 @@ export type RequestOptions = {
   reset?: boolean;
   /** Default: `64 KiB` */
   highWaterMark?: number;
-  signal?: AbortSignal | EventEmitter;
+  signal?: globalThis.AbortSignal | EventEmitter;
 };
 
 export type RequestMeta = {

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -141,6 +141,11 @@ export type RequestOptions = {
   ctx?: unknown;
   /** Request dispatcher, default is getGlobalDispatcher() */
   dispatcher?: Dispatcher;
+  /**
+   * Negotiate HTTP/2 with capable servers via ALPN. Enabled by default since undici@8; set `false` to force HTTP/1.1
+   * for this request without bypassing the active dispatcher.
+   */
+  allowH2?: boolean;
   /** Unix domain socket file path */
   socketPath?: string | null;
   /** Whether the request should stablish a keep-alive or not. Default `false`, try to keep alive by default */

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,11 +1,8 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { debuglog } from 'node:util';
 
-import { fetch as UndiciFetch, Request, Response, Agent, getGlobalDispatcher, Pool, Dispatcher } from 'undici';
+import { fetch as UndiciFetch, Request, Response, Agent, getGlobalDispatcher, Dispatcher } from 'undici';
 import type { RequestInfo, RequestInit } from 'undici';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import undiciSymbols from 'undici/lib/core/symbols.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { getResponseState } from 'undici/lib/web/fetch/response.js';
@@ -16,7 +13,7 @@ import { initDiagnosticsChannel } from './diagnosticsChannel.js';
 import type { FetchOpaque } from './FetchOpaqueInterceptor.js';
 import { HttpAgent } from './HttpAgent.js';
 import type { HttpAgentOptions } from './HttpAgent.js';
-import { channels, mergePoolStat, normalizePoolStatsKey } from './HttpClient.js';
+import { buildPoolStats, channels } from './HttpClient.js';
 import type {
   ClientOptions,
   PoolStat,
@@ -99,25 +96,7 @@ export class FetchFactory {
   }
 
   getDispatcherPoolStats(): Record<string, PoolStat> {
-    const agent = this.getDispatcher();
-    // origin => Pool Instance
-    const clients: Map<string, WeakRef<Pool>> | undefined = Reflect.get(agent, undiciSymbols.kClients);
-    const poolStatsMap: Record<string, PoolStat> = {};
-    if (!clients) {
-      return poolStatsMap;
-    }
-    for (const [key, ref] of clients) {
-      const pool = (typeof ref.deref === 'function' ? ref.deref() : ref) as unknown as Pool & { dispatcher: Pool };
-      // NOTE: pool become to { dispatcher: Pool } in undici@v7
-      const stats = pool?.stats ?? pool?.dispatcher?.stats;
-      if (!stats) continue;
-
-      // undici@8 keys http1-only pools (allowH2: false) as `${origin}#http1-only`,
-      // expose them by their origin so callers can look up stats by URL.
-      const origin = normalizePoolStatsKey(key);
-      poolStatsMap[origin] = mergePoolStat(poolStatsMap[origin], stats as PoolStat);
-    }
-    return poolStatsMap;
+    return buildPoolStats(this.getDispatcher());
   }
 
   static setClientOptions(clientOptions: ClientOptions): void {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -77,8 +77,9 @@ export class FetchFactory {
         allowH2: clientOptions.allowH2,
       } as HttpAgentOptions;
       dispatcherClazz = BaseAgent;
-    } else if (clientOptions?.allowH2) {
-      // Support HTTP2
+    } else if (clientOptions?.allowH2 !== undefined) {
+      // Pin the protocol when allowH2 is set explicitly: `true` enables HTTP/2,
+      // `false` forces HTTP/1.1 instead of following undici@8's HTTP/2 default.
       dispatcherOption = {
         ...dispatcherOption,
         allowH2: clientOptions.allowH2,

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -16,7 +16,7 @@ import { initDiagnosticsChannel } from './diagnosticsChannel.js';
 import type { FetchOpaque } from './FetchOpaqueInterceptor.js';
 import { HttpAgent } from './HttpAgent.js';
 import type { HttpAgentOptions } from './HttpAgent.js';
-import { channels } from './HttpClient.js';
+import { channels, mergePoolStat, normalizePoolStatsKey } from './HttpClient.js';
 import type {
   ClientOptions,
   PoolStat,
@@ -112,14 +112,10 @@ export class FetchFactory {
       const stats = pool?.stats ?? pool?.dispatcher?.stats;
       if (!stats) continue;
 
-      poolStatsMap[key] = {
-        connected: stats.connected,
-        free: stats.free,
-        pending: stats.pending,
-        queued: stats.queued,
-        running: stats.running,
-        size: stats.size,
-      } satisfies PoolStat;
+      // undici@8 keys http1-only pools (allowH2: false) as `${origin}#http1-only`,
+      // expose them by their origin so callers can look up stats by URL.
+      const origin = normalizePoolStatsKey(key);
+      poolStatsMap[origin] = mergePoolStat(poolStatsMap[origin], stats as PoolStat);
     }
     return poolStatsMap;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const domainSocketHttpClients = new LRU(50);
 // request. The `rejectUnauthorized: false` variants are the exception: they must own
 // an agent to carry the TLS option, so those bypass the global dispatcher (as before).
 export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boolean): HttpClient {
-  const key = `${rejectUnauthorized === false ? 0 : 1}:${allowH2 === true ? 1 : allowH2 === false ? 0 : -1}`;
+  const key = `rejectUnauthorized=${rejectUnauthorized === false}:allowH2=${allowH2 ?? 'default'}`;
   let client = httpClients.get(key);
   if (!client) {
     const clientOptions: ClientOptions = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,16 @@ import type { HttpClientResponse } from './Response.js';
 
 let httpClient: HttpClient;
 let allowH2HttpClient: HttpClient;
-let disallowH2HttpClient: HttpClient;
 let allowUnauthorizedHttpClient: HttpClient;
 let allowH2AndUnauthorizedHttpClient: HttpClient;
-let disallowH2AndUnauthorizedHttpClient: HttpClient;
 const domainSocketHttpClients = new LRU(50);
 
+// Only `allowH2: true` needs a dedicated agent; `allowH2: false` is applied per
+// request (see HttpClient#request) so it forces HTTP/1.1 through the active
+// dispatcher (e.g. a global ProxyAgent) instead of bypassing it.
 export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boolean): HttpClient {
   if (rejectUnauthorized === false) {
-    if (allowH2 === true) {
+    if (allowH2) {
       if (!allowH2AndUnauthorizedHttpClient) {
         allowH2AndUnauthorizedHttpClient = new HttpClient({
           allowH2,
@@ -24,18 +25,6 @@ export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boo
         });
       }
       return allowH2AndUnauthorizedHttpClient;
-    }
-
-    if (allowH2 === false) {
-      if (!disallowH2AndUnauthorizedHttpClient) {
-        disallowH2AndUnauthorizedHttpClient = new HttpClient({
-          allowH2,
-          connect: {
-            rejectUnauthorized,
-          },
-        });
-      }
-      return disallowH2AndUnauthorizedHttpClient;
     }
 
     if (!allowUnauthorizedHttpClient) {
@@ -48,22 +37,13 @@ export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boo
     return allowUnauthorizedHttpClient;
   }
 
-  if (allowH2 === true) {
+  if (allowH2) {
     if (!allowH2HttpClient) {
       allowH2HttpClient = new HttpClient({
         allowH2,
       });
     }
     return allowH2HttpClient;
-  }
-
-  if (allowH2 === false) {
-    if (!disallowH2HttpClient) {
-      disallowH2HttpClient = new HttpClient({
-        allowH2,
-      });
-    }
-    return disallowH2HttpClient;
   }
 
   if (!httpClient) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,16 +6,18 @@ import type { HttpClientResponse } from './Response.js';
 
 let httpClient: HttpClient;
 let allowH2HttpClient: HttpClient;
+let disallowH2HttpClient: HttpClient;
 let allowUnauthorizedHttpClient: HttpClient;
 let allowH2AndUnauthorizedHttpClient: HttpClient;
+let disallowH2AndUnauthorizedHttpClient: HttpClient;
 const domainSocketHttpClients = new LRU(50);
 
-// Only `allowH2: true` needs a dedicated agent; `allowH2: false` is applied per
-// request (see HttpClient#request) so it forces HTTP/1.1 through the active
-// dispatcher (e.g. a global ProxyAgent) instead of bypassing it.
+// Only `allowH2: true` needs a dedicated agent. `allowH2: false` clients keep the
+// preference (so `request(url)` on them forces HTTP/1.1) but do not create their
+// own dispatcher, so they still go through the active/global dispatcher per request.
 export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boolean): HttpClient {
   if (rejectUnauthorized === false) {
-    if (allowH2) {
+    if (allowH2 === true) {
       if (!allowH2AndUnauthorizedHttpClient) {
         allowH2AndUnauthorizedHttpClient = new HttpClient({
           allowH2,
@@ -25,6 +27,18 @@ export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boo
         });
       }
       return allowH2AndUnauthorizedHttpClient;
+    }
+
+    if (allowH2 === false) {
+      if (!disallowH2AndUnauthorizedHttpClient) {
+        disallowH2AndUnauthorizedHttpClient = new HttpClient({
+          allowH2,
+          connect: {
+            rejectUnauthorized,
+          },
+        });
+      }
+      return disallowH2AndUnauthorizedHttpClient;
     }
 
     if (!allowUnauthorizedHttpClient) {
@@ -37,13 +51,22 @@ export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boo
     return allowUnauthorizedHttpClient;
   }
 
-  if (allowH2) {
+  if (allowH2 === true) {
     if (!allowH2HttpClient) {
       allowH2HttpClient = new HttpClient({
         allowH2,
       });
     }
     return allowH2HttpClient;
+  }
+
+  if (allowH2 === false) {
+    if (!disallowH2HttpClient) {
+      disallowH2HttpClient = new HttpClient({
+        allowH2,
+      });
+    }
+    return disallowH2HttpClient;
   }
 
   if (!httpClient) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,11 @@ let allowH2AndUnauthorizedHttpClient: HttpClient;
 let disallowH2AndUnauthorizedHttpClient: HttpClient;
 const domainSocketHttpClients = new LRU(50);
 
-// Only `allowH2: true` needs a dedicated agent. `allowH2: false` clients keep the
-// preference (so `request(url)` on them forces HTTP/1.1) but do not create their
-// own dispatcher, so they still go through the active/global dispatcher per request.
+// `allowH2: false` clients keep the preference (so `request(url)` on them forces
+// HTTP/1.1) and, unless they need a dedicated agent for other reasons, do not create
+// their own dispatcher, so they still go through the active/global dispatcher per
+// request. The `rejectUnauthorized: false` variants are the exception: they must own
+// an agent to carry the TLS option, so those bypass the global dispatcher (as before).
 export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boolean): HttpClient {
   if (rejectUnauthorized === false) {
     if (allowH2 === true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,12 @@
 import { LRU } from 'ylru';
 
 import { HttpClient, HEADER_USER_AGENT } from './HttpClient.js';
+import type { ClientOptions } from './HttpClient.js';
 import type { RequestOptions, RequestURL } from './Request.js';
 import type { HttpClientResponse } from './Response.js';
 
-let httpClient: HttpClient;
-let allowH2HttpClient: HttpClient;
-let disallowH2HttpClient: HttpClient;
-let allowUnauthorizedHttpClient: HttpClient;
-let allowH2AndUnauthorizedHttpClient: HttpClient;
-let disallowH2AndUnauthorizedHttpClient: HttpClient;
+// Cache one client per (rejectUnauthorized, allowH2) combination.
+const httpClients = new Map<string, HttpClient>();
 const domainSocketHttpClients = new LRU(50);
 
 // `allowH2: false` clients keep the preference (so `request(url)` on them forces
@@ -18,63 +15,20 @@ const domainSocketHttpClients = new LRU(50);
 // request. The `rejectUnauthorized: false` variants are the exception: they must own
 // an agent to carry the TLS option, so those bypass the global dispatcher (as before).
 export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boolean): HttpClient {
-  if (rejectUnauthorized === false) {
-    if (allowH2 === true) {
-      if (!allowH2AndUnauthorizedHttpClient) {
-        allowH2AndUnauthorizedHttpClient = new HttpClient({
-          allowH2,
-          connect: {
-            rejectUnauthorized,
-          },
-        });
-      }
-      return allowH2AndUnauthorizedHttpClient;
+  const key = `${rejectUnauthorized === false ? 0 : 1}:${allowH2 === true ? 1 : allowH2 === false ? 0 : -1}`;
+  let client = httpClients.get(key);
+  if (!client) {
+    const clientOptions: ClientOptions = {};
+    if (typeof allowH2 === 'boolean') {
+      clientOptions.allowH2 = allowH2;
     }
-
-    if (allowH2 === false) {
-      if (!disallowH2AndUnauthorizedHttpClient) {
-        disallowH2AndUnauthorizedHttpClient = new HttpClient({
-          allowH2,
-          connect: {
-            rejectUnauthorized,
-          },
-        });
-      }
-      return disallowH2AndUnauthorizedHttpClient;
+    if (rejectUnauthorized === false) {
+      clientOptions.connect = { rejectUnauthorized };
     }
-
-    if (!allowUnauthorizedHttpClient) {
-      allowUnauthorizedHttpClient = new HttpClient({
-        connect: {
-          rejectUnauthorized,
-        },
-      });
-    }
-    return allowUnauthorizedHttpClient;
+    client = new HttpClient(clientOptions);
+    httpClients.set(key, client);
   }
-
-  if (allowH2 === true) {
-    if (!allowH2HttpClient) {
-      allowH2HttpClient = new HttpClient({
-        allowH2,
-      });
-    }
-    return allowH2HttpClient;
-  }
-
-  if (allowH2 === false) {
-    if (!disallowH2HttpClient) {
-      disallowH2HttpClient = new HttpClient({
-        allowH2,
-      });
-    }
-    return disallowH2HttpClient;
-  }
-
-  if (!httpClient) {
-    httpClient = new HttpClient();
-  }
-  return httpClient;
+  return client;
 }
 
 interface UrllibRequestOptions extends RequestOptions {
@@ -83,8 +37,7 @@ interface UrllibRequestOptions extends RequestOptions {
    * verification fails. Default: `true`
    */
   rejectUnauthorized?: boolean;
-  /** Negotiate HTTP/2 with capable servers via ALPN. Enabled by default since undici@8; set `false` to force HTTP/1.1. */
-  allowH2?: boolean;
+  // `allowH2` is inherited from RequestOptions.
 }
 
 export async function request<T = any>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ interface UrllibRequestOptions extends RequestOptions {
    * verification fails. Default: `true`
    */
   rejectUnauthorized?: boolean;
-  /** Allow to use HTTP2 first. Default is `false` */
+  /** Allow negotiating HTTP/2 with capable servers via ALPN. Since undici@8 this is enabled by default. */
   allowH2?: boolean;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,15 @@ import type { HttpClientResponse } from './Response.js';
 
 let httpClient: HttpClient;
 let allowH2HttpClient: HttpClient;
+let disallowH2HttpClient: HttpClient;
 let allowUnauthorizedHttpClient: HttpClient;
 let allowH2AndUnauthorizedHttpClient: HttpClient;
+let disallowH2AndUnauthorizedHttpClient: HttpClient;
 const domainSocketHttpClients = new LRU(50);
 
 export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boolean): HttpClient {
   if (rejectUnauthorized === false) {
-    if (allowH2) {
+    if (allowH2 === true) {
       if (!allowH2AndUnauthorizedHttpClient) {
         allowH2AndUnauthorizedHttpClient = new HttpClient({
           allowH2,
@@ -22,6 +24,18 @@ export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boo
         });
       }
       return allowH2AndUnauthorizedHttpClient;
+    }
+
+    if (allowH2 === false) {
+      if (!disallowH2AndUnauthorizedHttpClient) {
+        disallowH2AndUnauthorizedHttpClient = new HttpClient({
+          allowH2,
+          connect: {
+            rejectUnauthorized,
+          },
+        });
+      }
+      return disallowH2AndUnauthorizedHttpClient;
     }
 
     if (!allowUnauthorizedHttpClient) {
@@ -34,13 +48,22 @@ export function getDefaultHttpClient(rejectUnauthorized?: boolean, allowH2?: boo
     return allowUnauthorizedHttpClient;
   }
 
-  if (allowH2) {
+  if (allowH2 === true) {
     if (!allowH2HttpClient) {
       allowH2HttpClient = new HttpClient({
         allowH2,
       });
     }
     return allowH2HttpClient;
+  }
+
+  if (allowH2 === false) {
+    if (!disallowH2HttpClient) {
+      disallowH2HttpClient = new HttpClient({
+        allowH2,
+      });
+    }
+    return disallowH2HttpClient;
   }
 
   if (!httpClient) {
@@ -55,7 +78,7 @@ interface UrllibRequestOptions extends RequestOptions {
    * verification fails. Default: `true`
    */
   rejectUnauthorized?: boolean;
-  /** Allow negotiating HTTP/2 with capable servers via ALPN. Since undici@8 this is enabled by default. */
+  /** Negotiate HTTP/2 with capable servers via ALPN. Enabled by default since undici@8; set `false` to force HTTP/1.1. */
   allowH2?: boolean;
 }
 

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import dns from 'node:dns';
 import { once } from 'node:events';
 import { sensitiveHeaders, createSecureServer } from 'node:http2';
+import { createServer as createSecureHttp1Server } from 'node:https';
 import type { AddressInfo } from 'node:net';
 import { PerformanceObserver } from 'node:perf_hooks';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -246,6 +247,63 @@ describe('HttpClient.test.ts', () => {
       assert.equal(response.headers['x-custom-h2'], 'hello');
       // console.log(response.res.socket, response.res.timing);
       assert.equal(response.data, 'hello h2!');
+    });
+  });
+
+  describe('protocol negotiation', () => {
+    it('should use HTTP/1.1 when the server only supports HTTP/1.1', async () => {
+      const server = createSecureHttp1Server(
+        {
+          key: pems.private,
+          cert: pems.cert,
+        },
+        (req, res) => {
+          res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+          res.end(`hello http/${req.httpVersion}!`);
+        },
+      );
+      server.listen(0);
+      await once(server, 'listening');
+      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+
+      const httpClient = new HttpClient({
+        connect: { rejectUnauthorized: false },
+      });
+      try {
+        const response = await httpClient.request<string>(url, { dataType: 'text' });
+        assert.equal(response.status, 200);
+        assert.equal(response.data, 'hello http/1.1!');
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+
+    it('should negotiate HTTP/2 by default when the server supports it', async () => {
+      // undici@8 enables allowH2 by default, so urllib negotiates HTTP/2 via ALPN.
+      const server = createSecureServer({
+        allowHTTP1: true,
+        key: pems.private,
+        cert: pems.cert,
+      });
+      server.on('request', (req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+        res.end(`hello http/${req.httpVersion}!`);
+      });
+      server.listen(0);
+      await once(server, 'listening');
+      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+
+      const httpClient = new HttpClient({
+        connect: { rejectUnauthorized: false },
+      });
+      try {
+        const response = await httpClient.request<string>(url, { dataType: 'text' });
+        assert.equal(response.status, 200);
+        assert.equal(response.data, 'hello http/2.0!');
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     });
   });
 

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -8,6 +8,9 @@ import { PerformanceObserver } from 'node:perf_hooks';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import selfsigned from 'selfsigned';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import undiciSymbols from 'undici/lib/core/symbols.js';
 import { describe, it, beforeAll, afterAll } from 'vite-plus/test';
 
 import { mergePoolStat, normalizePoolStatsKey } from '../src/HttpClient.js';
@@ -446,18 +449,45 @@ describe('HttpClient.test.ts', () => {
       // http1-only pool (key `${origin}#http1-only`) must collapse into one entry.
       const httpClient = new HttpClient({ connect: { rejectUnauthorized: false } });
       try {
-        const h2 = await httpClient.request<string>(url, { dataType: 'text' });
-        assert.equal(h2.data, 'hello http/2.0!');
-        const h1 = await httpClient.request<string>(url, { dataType: 'text', allowH2: false });
-        assert.equal(h1.data, 'hello http/1.1!');
+        // many concurrent HTTP/1.1 requests open several http1-only connections,
+        // while concurrent HTTP/2 requests multiplex over a single connection.
+        const h2Responses = await Promise.all(
+          Array.from({ length: 5 }, () => httpClient.request<string>(url, { dataType: 'text' })),
+        );
+        for (const r of h2Responses) assert.equal(r.data, 'hello http/2.0!');
+        const h1Responses = await Promise.all(
+          Array.from({ length: 8 }, () => httpClient.request<string>(url, { dataType: 'text', allowH2: false })),
+        );
+        for (const r of h1Responses) assert.equal(r.data, 'hello http/1.1!');
+
+        // read the two raw undici pools for this origin to compute the expected sum
+        const clients = Reflect.get(httpClient.getDispatcher(), undiciSymbols.kClients) as Map<string, any>;
+        const readStats = (key: string) => {
+          const ref = clients.get(key);
+          const pool = typeof ref?.deref === 'function' ? ref.deref() : ref;
+          return pool?.stats ?? pool?.dispatcher?.stats;
+        };
+        const h2Stats = readStats(url);
+        const h1Stats = readStats(`${url}#http1-only`);
+        assert(h2Stats, 'expected a separate HTTP/2 pool');
+        assert(h1Stats, 'expected a separate http1-only pool');
+        // the concurrent HTTP/1.1 requests really did open more than one connection,
+        // so the merge is non-trivial (otherwise this would just be 1 + 1)
+        assert(h1Stats.connected > 1, `expected >1 http1-only connections, got ${h1Stats.connected}`);
 
         const stats = httpClient.getDispatcherPoolStats();
         // both pools collapse to a single origin entry, no leaked `#http1-only` suffix
         assert(!Object.keys(stats).some((k) => k.includes('#http1-only')));
         assert(stats[url], `expected merged stats for ${url}, got ${Object.keys(stats).join(', ')}`);
-        // each keep-alive pool holds one connection; the merged entry sums them (2),
-        // proving the http1-only pool is added to the HTTP/2 one instead of overwriting it
-        assert.equal(stats[url].connected, 2);
+        // the merged entry must equal the field-by-field sum of both pools (not an overwrite)
+        const counters = ['connected', 'free', 'pending', 'queued', 'running', 'size'] as const;
+        for (const counter of counters) {
+          assert.equal(
+            stats[url][counter],
+            (h2Stats[counter] ?? 0) + (h1Stats[counter] ?? 0),
+            `merged ${counter} should be the sum of both pools`,
+          );
+        }
       } finally {
         await httpClient.getDispatcher().close();
         await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -371,6 +371,13 @@ describe('HttpClient.test.ts', () => {
       assert.notEqual(disallowH2, getDefaultHttpClient(undefined, true));
       // ... without creating its own dispatcher (so global ProxyAgent/MockAgent is honored)
       assert.equal(disallowH2.getDispatcher(), getGlobalDispatcher());
+
+      // rejectUnauthorized: false has its own cached allowH2: false client
+      const disallowH2Unauthorized = getDefaultHttpClient(false, false);
+      assert.equal(disallowH2Unauthorized, getDefaultHttpClient(false, false));
+      assert.notEqual(disallowH2Unauthorized, disallowH2);
+      assert.notEqual(disallowH2Unauthorized, getDefaultHttpClient(false, undefined));
+      assert.notEqual(disallowH2Unauthorized, getDefaultHttpClient(false, true));
     });
 
     it('should force HTTP/1.1 per request via allowH2: false and expose pool stats by origin', async () => {

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import dns from 'node:dns';
 import { once } from 'node:events';
 import { sensitiveHeaders, createSecureServer } from 'node:http2';
+import type { Http2SecureServer } from 'node:http2';
 import { createServer as createSecureHttp1Server } from 'node:https';
 import type { AddressInfo } from 'node:net';
 import { PerformanceObserver } from 'node:perf_hooks';
@@ -21,6 +22,19 @@ import { startServer } from './fixtures/server.js';
 const pems = selfsigned.generate([], {
   keySize: 2048,
 });
+
+// Start a TLS server that speaks both HTTP/2 and HTTP/1.1 (ALPN) and echoes the
+// negotiated protocol, shared by the protocol-negotiation / pool-stats tests.
+async function startH2EchoServer(): Promise<{ url: string; server: Http2SecureServer }> {
+  const server = createSecureServer({ allowHTTP1: true, key: pems.private, cert: pems.cert });
+  server.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+    res.end(`hello http/${req.httpVersion}!`);
+  });
+  server.listen(0);
+  await once(server, 'listening');
+  return { url: `https://localhost:${(server.address() as AddressInfo).port}`, server };
+}
 
 if (process.env.ENABLE_PERF) {
   const obs = new PerformanceObserver((items) => {
@@ -285,18 +299,7 @@ describe('HttpClient.test.ts', () => {
 
     it('should negotiate HTTP/2 by default when the server supports it', async () => {
       // undici@8 enables allowH2 by default, so urllib negotiates HTTP/2 via ALPN.
-      const server = createSecureServer({
-        allowHTTP1: true,
-        key: pems.private,
-        cert: pems.cert,
-      });
-      server.on('request', (req, res) => {
-        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-        res.end(`hello http/${req.httpVersion}!`);
-      });
-      server.listen(0);
-      await once(server, 'listening');
-      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+      const { url, server } = await startH2EchoServer();
 
       const httpClient = new HttpClient({
         connect: { rejectUnauthorized: false },
@@ -312,18 +315,7 @@ describe('HttpClient.test.ts', () => {
     });
 
     it('should force HTTP/1.1 with allowH2 = false even if the server supports HTTP/2', async () => {
-      const server = createSecureServer({
-        allowHTTP1: true,
-        key: pems.private,
-        cert: pems.cert,
-      });
-      server.on('request', (req, res) => {
-        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-        res.end(`hello http/${req.httpVersion}!`);
-      });
-      server.listen(0);
-      await once(server, 'listening');
-      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+      const { url, server } = await startH2EchoServer();
 
       const httpClient = new HttpClient({
         allowH2: false,
@@ -400,18 +392,7 @@ describe('HttpClient.test.ts', () => {
     });
 
     it('should force HTTP/1.1 per request via allowH2: false and expose pool stats by origin', async () => {
-      const server = createSecureServer({
-        allowHTTP1: true,
-        key: pems.private,
-        cert: pems.cert,
-      });
-      server.on('request', (req, res) => {
-        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-        res.end(`hello http/${req.httpVersion}!`);
-      });
-      server.listen(0);
-      await once(server, 'listening');
-      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+      const { url, server } = await startH2EchoServer();
 
       // the client keeps its (HTTP/2-capable) dispatcher; allowH2: false is per request
       const httpClient = new HttpClient({ connect: { rejectUnauthorized: false } });
@@ -432,18 +413,7 @@ describe('HttpClient.test.ts', () => {
     });
 
     it('getDispatcherPoolStats should merge HTTP/2 and HTTP/1.1 pools for the same origin', async () => {
-      const server = createSecureServer({
-        allowHTTP1: true,
-        key: pems.private,
-        cert: pems.cert,
-      });
-      server.on('request', (req, res) => {
-        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-        res.end(`hello http/${req.httpVersion}!`);
-      });
-      server.listen(0);
-      await once(server, 'listening');
-      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+      const { url, server } = await startH2EchoServer();
 
       // same dispatcher, same origin: one HTTP/2 pool (key `${origin}`) and one
       // http1-only pool (key `${origin}#http1-only`) must collapse into one entry.
@@ -495,18 +465,7 @@ describe('HttpClient.test.ts', () => {
     });
 
     it('should honor per-request allowH2: false for HttpAgent (checkAddress) clients', async () => {
-      const server = createSecureServer({
-        allowHTTP1: true,
-        key: pems.private,
-        cert: pems.cert,
-      });
-      server.on('request', (req, res) => {
-        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-        res.end(`hello http/${req.httpVersion}!`);
-      });
-      server.listen(0);
-      await once(server, 'listening');
-      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+      const { url, server } = await startH2EchoServer();
 
       // checkAddress routes through HttpAgent; allowH2 must stay top-level so the
       // per-request flag still reaches undici's connector (ALPN).

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -362,6 +362,22 @@ describe('HttpClient.test.ts', () => {
       assert(!Number.isNaN(merged.free) && !Number.isNaN(merged.queued));
     });
 
+    it('mergePoolStat should sum every counter across H2 and HTTP/1.1 pools', () => {
+      // no existing entry yet: returns the first pool's counters as-is
+      const h2 = { connected: 1, free: 2, pending: 3, queued: 4, running: 5, size: 6 };
+      assert.deepEqual(mergePoolStat(undefined, h2), h2);
+      // second pool for the same origin: every counter must be summed, not overwritten
+      const h1 = { connected: 10, free: 20, pending: 30, queued: 40, running: 50, size: 60 };
+      assert.deepEqual(mergePoolStat(h2, h1), {
+        connected: 11,
+        free: 22,
+        pending: 33,
+        queued: 44,
+        running: 55,
+        size: 66,
+      });
+    });
+
     it('should cache a distinct allowH2: false default client that still uses the global dispatcher', () => {
       // a dedicated cached client carries the allowH2: false preference so that
       // getDefaultHttpClient(undefined, false).request(url) forces HTTP/1.1 ...
@@ -406,6 +422,42 @@ describe('HttpClient.test.ts', () => {
         const stats = httpClient.getDispatcherPoolStats();
         assert(stats[url], `expected stats for ${url}, got ${Object.keys(stats).join(', ')}`);
         assert(!Object.keys(stats).some((k) => k.includes('#http1-only')));
+      } finally {
+        await httpClient.getDispatcher().close();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+
+    it('getDispatcherPoolStats should merge HTTP/2 and HTTP/1.1 pools for the same origin', async () => {
+      const server = createSecureServer({
+        allowHTTP1: true,
+        key: pems.private,
+        cert: pems.cert,
+      });
+      server.on('request', (req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+        res.end(`hello http/${req.httpVersion}!`);
+      });
+      server.listen(0);
+      await once(server, 'listening');
+      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+
+      // same dispatcher, same origin: one HTTP/2 pool (key `${origin}`) and one
+      // http1-only pool (key `${origin}#http1-only`) must collapse into one entry.
+      const httpClient = new HttpClient({ connect: { rejectUnauthorized: false } });
+      try {
+        const h2 = await httpClient.request<string>(url, { dataType: 'text' });
+        assert.equal(h2.data, 'hello http/2.0!');
+        const h1 = await httpClient.request<string>(url, { dataType: 'text', allowH2: false });
+        assert.equal(h1.data, 'hello http/1.1!');
+
+        const stats = httpClient.getDispatcherPoolStats();
+        // both pools collapse to a single origin entry, no leaked `#http1-only` suffix
+        assert(!Object.keys(stats).some((k) => k.includes('#http1-only')));
+        assert(stats[url], `expected merged stats for ${url}, got ${Object.keys(stats).join(', ')}`);
+        // each keep-alive pool holds one connection; the merged entry sums them (2),
+        // proving the http1-only pool is added to the HTTP/2 one instead of overwriting it
+        assert.equal(stats[url].connected, 2);
       } finally {
         await httpClient.getDispatcher().close();
         await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import selfsigned from 'selfsigned';
 import { describe, it, beforeAll, afterAll } from 'vite-plus/test';
 
-import { HttpClient, getGlobalDispatcher } from '../src/index.js';
+import { HttpClient, getDefaultHttpClient, getGlobalDispatcher } from '../src/index.js';
 import type { RawResponseWithMeta } from '../src/index.js';
 import { startServer } from './fixtures/server.js';
 
@@ -274,7 +274,7 @@ describe('HttpClient.test.ts', () => {
         assert.equal(response.status, 200);
         assert.equal(response.data, 'hello http/1.1!');
       } finally {
-        server.closeAllConnections();
+        await httpClient.getDispatcher().close();
         await new Promise<void>((resolve) => server.close(() => resolve()));
       }
     });
@@ -302,8 +302,50 @@ describe('HttpClient.test.ts', () => {
         assert.equal(response.status, 200);
         assert.equal(response.data, 'hello http/2.0!');
       } finally {
+        await httpClient.getDispatcher().close();
         await new Promise<void>((resolve) => server.close(() => resolve()));
       }
+    });
+
+    it('should force HTTP/1.1 with allowH2 = false even if the server supports HTTP/2', async () => {
+      const server = createSecureServer({
+        allowHTTP1: true,
+        key: pems.private,
+        cert: pems.cert,
+      });
+      server.on('request', (req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+        res.end(`hello http/${req.httpVersion}!`);
+      });
+      server.listen(0);
+      await once(server, 'listening');
+      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+
+      const httpClient = new HttpClient({
+        allowH2: false,
+        connect: { rejectUnauthorized: false },
+      });
+      try {
+        const response = await httpClient.request<string>(url, { dataType: 'text' });
+        assert.equal(response.status, 200);
+        assert.equal(response.data, 'hello http/1.1!');
+      } finally {
+        await httpClient.getDispatcher().close();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+
+    it('should pin a dedicated dispatcher when allowH2 is set explicitly', () => {
+      // allowH2: false must not fall back to undici@8's HTTP/2-enabled global dispatcher
+      assert.notEqual(new HttpClient({ allowH2: false }).getDispatcher(), getGlobalDispatcher());
+      assert.notEqual(new HttpClient({ allowH2: true }).getDispatcher(), getGlobalDispatcher());
+    });
+
+    it('should cache distinct default clients per allowH2 value', () => {
+      assert.equal(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, false));
+      assert.notEqual(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, true));
+      assert.notEqual(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, undefined));
+      assert.notEqual(getDefaultHttpClient(false, false), getDefaultHttpClient(false, true));
     });
   });
 

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -4,6 +4,7 @@ import { once } from 'node:events';
 import { sensitiveHeaders, createSecureServer } from 'node:http2';
 import type { Http2SecureServer } from 'node:http2';
 import { createServer as createSecureHttp1Server } from 'node:https';
+import type { Server as HttpsServer } from 'node:https';
 import type { AddressInfo } from 'node:net';
 import { PerformanceObserver } from 'node:perf_hooks';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -23,17 +24,31 @@ const pems = selfsigned.generate([], {
   keySize: 2048,
 });
 
-// Start a TLS server that speaks both HTTP/2 and HTTP/1.1 (ALPN) and echoes the
-// negotiated protocol, shared by the protocol-negotiation / pool-stats tests.
-async function startH2EchoServer(): Promise<{ url: string; server: Http2SecureServer }> {
-  const server = createSecureServer({ allowHTTP1: true, key: pems.private, cert: pems.cert });
-  server.on('request', (req, res) => {
+// Wire up a TLS server that echoes the negotiated protocol and return its url +
+// teardown, shared by the protocol-negotiation / pool-stats tests.
+async function startEchoServer(
+  server: Http2SecureServer | HttpsServer,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  (server as Http2SecureServer).on('request', (req, res) => {
     res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
     res.end(`hello http/${req.httpVersion}!`);
   });
   server.listen(0);
   await once(server, 'listening');
-  return { url: `https://localhost:${(server.address() as AddressInfo).port}`, server };
+  return {
+    url: `https://localhost:${(server.address() as AddressInfo).port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+// Speaks both HTTP/2 and HTTP/1.1 over ALPN (default negotiates HTTP/2).
+function startH2EchoServer() {
+  return startEchoServer(createSecureServer({ allowHTTP1: true, key: pems.private, cert: pems.cert }));
+}
+
+// HTTP/1.1 only (no ALPN h2 offer).
+function startH1EchoServer() {
+  return startEchoServer(createSecureHttp1Server({ key: pems.private, cert: pems.cert }));
 }
 
 if (process.env.ENABLE_PERF) {
@@ -270,19 +285,7 @@ describe('HttpClient.test.ts', () => {
 
   describe('protocol negotiation', () => {
     it('should use HTTP/1.1 when the server only supports HTTP/1.1', async () => {
-      const server = createSecureHttp1Server(
-        {
-          key: pems.private,
-          cert: pems.cert,
-        },
-        (req, res) => {
-          res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-          res.end(`hello http/${req.httpVersion}!`);
-        },
-      );
-      server.listen(0);
-      await once(server, 'listening');
-      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+      const { url, close } = await startH1EchoServer();
 
       const httpClient = new HttpClient({
         connect: { rejectUnauthorized: false },
@@ -293,13 +296,13 @@ describe('HttpClient.test.ts', () => {
         assert.equal(response.data, 'hello http/1.1!');
       } finally {
         await httpClient.getDispatcher().close();
-        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await close();
       }
     });
 
     it('should negotiate HTTP/2 by default when the server supports it', async () => {
       // undici@8 enables allowH2 by default, so urllib negotiates HTTP/2 via ALPN.
-      const { url, server } = await startH2EchoServer();
+      const { url, close } = await startH2EchoServer();
 
       const httpClient = new HttpClient({
         connect: { rejectUnauthorized: false },
@@ -310,12 +313,12 @@ describe('HttpClient.test.ts', () => {
         assert.equal(response.data, 'hello http/2.0!');
       } finally {
         await httpClient.getDispatcher().close();
-        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await close();
       }
     });
 
     it('should force HTTP/1.1 with allowH2 = false even if the server supports HTTP/2', async () => {
-      const { url, server } = await startH2EchoServer();
+      const { url, close } = await startH2EchoServer();
 
       const httpClient = new HttpClient({
         allowH2: false,
@@ -327,7 +330,7 @@ describe('HttpClient.test.ts', () => {
         assert.equal(response.data, 'hello http/1.1!');
       } finally {
         await httpClient.getDispatcher().close();
-        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await close();
       }
     });
 
@@ -352,9 +355,9 @@ describe('HttpClient.test.ts', () => {
       const clientStats = { connected: 2, pending: 1, running: 1, size: 2 } as any;
       const merged = mergePoolStat(pool, clientStats);
       assert.equal(merged.connected, 3);
+      // missing free/queued count as 0 (a missing `?? 0` would make these NaN)
       assert.equal(merged.free, 1);
       assert.equal(merged.queued, 1);
-      assert(!Number.isNaN(merged.free) && !Number.isNaN(merged.queued));
     });
 
     it('mergePoolStat should sum every counter across H2 and HTTP/1.1 pools', () => {
@@ -392,7 +395,7 @@ describe('HttpClient.test.ts', () => {
     });
 
     it('should force HTTP/1.1 per request via allowH2: false and expose pool stats by origin', async () => {
-      const { url, server } = await startH2EchoServer();
+      const { url, close } = await startH2EchoServer();
 
       // the client keeps its (HTTP/2-capable) dispatcher; allowH2: false is per request
       const httpClient = new HttpClient({ connect: { rejectUnauthorized: false } });
@@ -408,19 +411,20 @@ describe('HttpClient.test.ts', () => {
         assert(!Object.keys(stats).some((k) => k.includes('#http1-only')));
       } finally {
         await httpClient.getDispatcher().close();
-        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await close();
       }
     });
 
     it('getDispatcherPoolStats should merge HTTP/2 and HTTP/1.1 pools for the same origin', async () => {
-      const { url, server } = await startH2EchoServer();
+      const { url, close } = await startH2EchoServer();
 
       // same dispatcher, same origin: one HTTP/2 pool (key `${origin}`) and one
       // http1-only pool (key `${origin}#http1-only`) must collapse into one entry.
       const httpClient = new HttpClient({ connect: { rejectUnauthorized: false } });
       try {
-        // many concurrent HTTP/1.1 requests open several http1-only connections,
-        // while concurrent HTTP/2 requests multiplex over a single connection.
+        // concurrent requests on both protocols open several connections per pool
+        // (HTTP/2 opens a new connection per in-flight request when none is free),
+        // so the merged stats are non-trivial sums rather than 1 + 1.
         const h2Responses = await Promise.all(
           Array.from({ length: 5 }, () => httpClient.request<string>(url, { dataType: 'text' })),
         );
@@ -442,7 +446,7 @@ describe('HttpClient.test.ts', () => {
         assert(h2Stats, 'expected a separate HTTP/2 pool');
         assert(h1Stats, 'expected a separate http1-only pool');
         // the concurrent HTTP/1.1 requests really did open more than one connection,
-        // so the merge is non-trivial (otherwise this would just be 1 + 1)
+        // so the merge sums multiple connections rather than a trivial single pool
         assert(h1Stats.connected > 1, `expected >1 http1-only connections, got ${h1Stats.connected}`);
 
         const stats = httpClient.getDispatcherPoolStats();
@@ -460,12 +464,12 @@ describe('HttpClient.test.ts', () => {
         }
       } finally {
         await httpClient.getDispatcher().close();
-        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await close();
       }
     });
 
     it('should honor per-request allowH2: false for HttpAgent (checkAddress) clients', async () => {
-      const { url, server } = await startH2EchoServer();
+      const { url, close } = await startH2EchoServer();
 
       // checkAddress routes through HttpAgent; allowH2 must stay top-level so the
       // per-request flag still reaches undici's connector (ALPN).
@@ -480,7 +484,7 @@ describe('HttpClient.test.ts', () => {
         assert.equal(h2.data, 'hello http/2.0!');
       } finally {
         await httpClient.getDispatcher().close();
-        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await close();
       }
     });
   });

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -335,17 +335,52 @@ describe('HttpClient.test.ts', () => {
       }
     });
 
-    it('should pin a dedicated dispatcher when allowH2 is set explicitly', () => {
-      // allowH2: false must not fall back to undici@8's HTTP/2-enabled global dispatcher
-      assert.notEqual(new HttpClient({ allowH2: false }).getDispatcher(), getGlobalDispatcher());
+    it('should not create a dedicated dispatcher for allowH2: false', () => {
+      // allowH2: true uses an isolated agent
       assert.notEqual(new HttpClient({ allowH2: true }).getDispatcher(), getGlobalDispatcher());
+      // allowH2: false is applied per request, so it must keep using the active
+      // (global) dispatcher instead of bypassing it with its own agent
+      assert.equal(new HttpClient({ allowH2: false }).getDispatcher(), getGlobalDispatcher());
     });
 
-    it('should cache distinct default clients per allowH2 value', () => {
-      assert.equal(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, false));
-      assert.notEqual(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, true));
-      assert.notEqual(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, undefined));
-      assert.notEqual(getDefaultHttpClient(false, false), getDefaultHttpClient(false, true));
+    it('should not allocate a separate default client for allowH2: false', () => {
+      // allowH2: false reuses the default client (handled per request), only
+      // allowH2: true gets its own cached client
+      assert.equal(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, undefined));
+      assert.equal(getDefaultHttpClient(false, false), getDefaultHttpClient(false, undefined));
+      assert.notEqual(getDefaultHttpClient(undefined, true), getDefaultHttpClient(undefined, undefined));
+    });
+
+    it('should force HTTP/1.1 per request via allowH2: false and expose pool stats by origin', async () => {
+      const server = createSecureServer({
+        allowHTTP1: true,
+        key: pems.private,
+        cert: pems.cert,
+      });
+      server.on('request', (req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+        res.end(`hello http/${req.httpVersion}!`);
+      });
+      server.listen(0);
+      await once(server, 'listening');
+      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+
+      // the client keeps its (HTTP/2-capable) dispatcher; allowH2: false is per request
+      const httpClient = new HttpClient({ connect: { rejectUnauthorized: false } });
+      try {
+        const response = await httpClient.request<string>(url, { dataType: 'text', allowH2: false });
+        assert.equal(response.status, 200);
+        assert.equal(response.data, 'hello http/1.1!');
+
+        // undici keys the http1-only pool as `${origin}#http1-only`; stats must be
+        // reachable by the plain origin and not leak the internal suffix
+        const stats = httpClient.getDispatcherPoolStats();
+        assert(stats[url], `expected stats for ${url}, got ${Object.keys(stats).join(', ')}`);
+        assert(!Object.keys(stats).some((k) => k.includes('#http1-only')));
+      } finally {
+        await httpClient.getDispatcher().close();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     });
   });
 

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -121,7 +121,9 @@ describe('HttpClient.test.ts', () => {
         httpClient.request(_url),
       ]);
       // console.log(httpClient.getDispatcherPoolStats());
-      assert.equal(httpClient.getDispatcherPoolStats()['https://registry.npmmirror.com'].connected, 4);
+      // undici@8 negotiates HTTP/2 with h2-capable servers, so all requests are
+      // multiplexed over a single connection instead of opening one per request.
+      assert.equal(httpClient.getDispatcherPoolStats()['https://registry.npmmirror.com'].connected, 1);
       assert(httpClient.getDispatcherPoolStats()[_url.substring(0, _url.length - 1)].connected > 1);
     });
 

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import selfsigned from 'selfsigned';
 import { describe, it, beforeAll, afterAll } from 'vite-plus/test';
 
-import { normalizePoolStatsKey } from '../src/HttpClient.js';
+import { mergePoolStat, normalizePoolStatsKey } from '../src/HttpClient.js';
 import { HttpClient, getDefaultHttpClient, getGlobalDispatcher } from '../src/index.js';
 import type { RawResponseWithMeta } from '../src/index.js';
 import { startServer } from './fixtures/server.js';
@@ -351,6 +351,17 @@ describe('HttpClient.test.ts', () => {
       assert.equal(normalizePoolStatsKey(/example/), '/example/');
     });
 
+    it('mergePoolStat should treat missing ClientStats counters as zero', () => {
+      const pool = { connected: 1, free: 1, pending: 1, queued: 1, running: 1, size: 1 };
+      // undici ClientStats (Agent with connections: 1) omit free/queued
+      const clientStats = { connected: 2, pending: 1, running: 1, size: 2 } as any;
+      const merged = mergePoolStat(pool, clientStats);
+      assert.equal(merged.connected, 3);
+      assert.equal(merged.free, 1);
+      assert.equal(merged.queued, 1);
+      assert(!Number.isNaN(merged.free) && !Number.isNaN(merged.queued));
+    });
+
     it('should cache a distinct allowH2: false default client that still uses the global dispatcher', () => {
       // a dedicated cached client carries the allowH2: false preference so that
       // getDefaultHttpClient(undefined, false).request(url) forces HTTP/1.1 ...
@@ -388,6 +399,37 @@ describe('HttpClient.test.ts', () => {
         const stats = httpClient.getDispatcherPoolStats();
         assert(stats[url], `expected stats for ${url}, got ${Object.keys(stats).join(', ')}`);
         assert(!Object.keys(stats).some((k) => k.includes('#http1-only')));
+      } finally {
+        await httpClient.getDispatcher().close();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+
+    it('should honor per-request allowH2: false for HttpAgent (checkAddress) clients', async () => {
+      const server = createSecureServer({
+        allowHTTP1: true,
+        key: pems.private,
+        cert: pems.cert,
+      });
+      server.on('request', (req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+        res.end(`hello http/${req.httpVersion}!`);
+      });
+      server.listen(0);
+      await once(server, 'listening');
+      const url = `https://localhost:${(server.address() as AddressInfo).port}`;
+
+      // checkAddress routes through HttpAgent; allowH2 must stay top-level so the
+      // per-request flag still reaches undici's connector (ALPN).
+      const httpClient = new HttpClient({
+        checkAddress: () => true,
+        connect: { rejectUnauthorized: false },
+      });
+      try {
+        const h1 = await httpClient.request<string>(url, { dataType: 'text', allowH2: false });
+        assert.equal(h1.data, 'hello http/1.1!');
+        const h2 = await httpClient.request<string>(url, { dataType: 'text' });
+        assert.equal(h2.data, 'hello http/2.0!');
       } finally {
         await httpClient.getDispatcher().close();
         await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/test/HttpClient.test.ts
+++ b/test/HttpClient.test.ts
@@ -10,6 +10,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import selfsigned from 'selfsigned';
 import { describe, it, beforeAll, afterAll } from 'vite-plus/test';
 
+import { normalizePoolStatsKey } from '../src/HttpClient.js';
 import { HttpClient, getDefaultHttpClient, getGlobalDispatcher } from '../src/index.js';
 import type { RawResponseWithMeta } from '../src/index.js';
 import { startServer } from './fixtures/server.js';
@@ -343,12 +344,22 @@ describe('HttpClient.test.ts', () => {
       assert.equal(new HttpClient({ allowH2: false }).getDispatcher(), getGlobalDispatcher());
     });
 
-    it('should not allocate a separate default client for allowH2: false', () => {
-      // allowH2: false reuses the default client (handled per request), only
-      // allowH2: true gets its own cached client
-      assert.equal(getDefaultHttpClient(undefined, false), getDefaultHttpClient(undefined, undefined));
-      assert.equal(getDefaultHttpClient(false, false), getDefaultHttpClient(false, undefined));
-      assert.notEqual(getDefaultHttpClient(undefined, true), getDefaultHttpClient(undefined, undefined));
+    it('normalizePoolStatsKey should strip the http1-only suffix and tolerate non-string keys', () => {
+      assert.equal(normalizePoolStatsKey('https://example.com'), 'https://example.com');
+      assert.equal(normalizePoolStatsKey('https://example.com#http1-only'), 'https://example.com');
+      // MockAgent may use RegExp/function origin matchers as client keys
+      assert.equal(normalizePoolStatsKey(/example/), '/example/');
+    });
+
+    it('should cache a distinct allowH2: false default client that still uses the global dispatcher', () => {
+      // a dedicated cached client carries the allowH2: false preference so that
+      // getDefaultHttpClient(undefined, false).request(url) forces HTTP/1.1 ...
+      const disallowH2 = getDefaultHttpClient(undefined, false);
+      assert.equal(disallowH2, getDefaultHttpClient(undefined, false));
+      assert.notEqual(disallowH2, getDefaultHttpClient(undefined, undefined));
+      assert.notEqual(disallowH2, getDefaultHttpClient(undefined, true));
+      // ... without creating its own dispatcher (so global ProxyAgent/MockAgent is honored)
+      assert.equal(disallowH2.getDispatcher(), getGlobalDispatcher());
     });
 
     it('should force HTTP/1.1 per request via allowH2: false and expose pool stats by origin', async () => {

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -23,6 +23,23 @@ describe('fetch.test.ts', () => {
     await close();
   });
 
+  it('setClientOptions should honor explicit allowH2 even without connect/lookup', () => {
+    // undici@8 enables HTTP/2 by default, so `allowH2: false` must still pin the
+    // dispatcher to HTTP/1.1 instead of being ignored as a falsy value.
+    const readAllowH2 = (dispatcher: any) => {
+      const kOptions = Object.getOwnPropertySymbols(dispatcher).find((s) => s.description === 'options');
+      return kOptions ? dispatcher[kOptions].allowH2 : undefined;
+    };
+
+    const disableH2 = new FetchFactory();
+    disableH2.setClientOptions({ allowH2: false });
+    assert.equal(readAllowH2(disableH2.getDispatcher()), false);
+
+    const enableH2 = new FetchFactory();
+    enableH2.setClientOptions({ allowH2: true });
+    assert.equal(readAllowH2(enableH2.getDispatcher()), true);
+  });
+
   it('fetch should work', async () => {
     let requestDiagnosticsMessage: RequestDiagnosticsMessage;
     let responseDiagnosticsMessage: ResponseDiagnosticsMessage;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -291,6 +291,29 @@ describe('index.test.ts', () => {
       mockAgent.assertNoPendingInterceptors();
     });
 
+    it('should keep using the mocked global dispatcher when allowH2 is false', async () => {
+      const mockPool = mockAgent.get(_url.substring(0, _url.length - 1));
+      mockPool
+        .intercept({
+          path: '/foo',
+          method: 'GET',
+        })
+        .reply(200, {
+          message: 'mocked http1 only',
+        });
+
+      // allowH2: false must not split the mock pool into an http1-only client,
+      // otherwise the interceptor is missed and the real server answers instead.
+      const response = await urllib.request(`${_url}foo`, {
+        method: 'GET',
+        allowH2: false,
+        dataType: 'json',
+      });
+      assert.equal(response.status, 200);
+      assert.deepEqual(response.data, { message: 'mocked http1 only' });
+      mockAgent.assertNoPendingInterceptors();
+    });
+
     it('should mocking intercept work with readable', async () => {
       const mockPool = mockAgent.get(_url.substring(0, _url.length - 1));
       // mock response stream

--- a/test/options.dispatcher.test.ts
+++ b/test/options.dispatcher.test.ts
@@ -11,6 +11,7 @@ describe('options.dispatcher.test.ts', () => {
   let _url: string;
   let proxyServer: any;
   let proxyServerUrl: string;
+  const proxyAgents: ProxyAgent[] = [];
   beforeAll(async () => {
     const { closeServer, url } = await startServer();
     close = closeServer;
@@ -27,6 +28,8 @@ describe('options.dispatcher.test.ts', () => {
 
   afterAll(async () => {
     await close();
+    // close keep-alive proxy connections so the proxy server can shut down
+    await Promise.all(proxyAgents.map((proxyAgent) => proxyAgent.close()));
     await new Promise((resolve) => {
       proxyServer.close(resolve);
     });
@@ -34,6 +37,7 @@ describe('options.dispatcher.test.ts', () => {
 
   it('should work with proxyAgent dispatcher', async () => {
     const proxyAgent = new ProxyAgent(proxyServerUrl);
+    proxyAgents.push(proxyAgent);
     const response = await request(`${_url}html`, {
       dispatcher: proxyAgent,
       dataType: 'text',
@@ -55,6 +59,7 @@ describe('options.dispatcher.test.ts', () => {
   it('should work with getGlobalDispatcher() dispatcher', async () => {
     const agent = getGlobalDispatcher();
     const proxyAgent = new ProxyAgent(proxyServerUrl);
+    proxyAgents.push(proxyAgent);
     setGlobalDispatcher(proxyAgent);
     const response = await request(`${_url}html`, {
       dataType: 'text',

--- a/test/options.timeout.test.ts
+++ b/test/options.timeout.test.ts
@@ -104,9 +104,10 @@ describe('options.timeout.test.ts', () => {
         // console.error(err);
         assert.equal(err.name, 'HttpClientRequestTimeoutError');
         assert.equal(err.message, 'Request timeout for 10 ms');
-        assert.equal(err.cause.name, 'InformationalError');
-        assert.equal(err.cause.message, 'HTTP/2: "stream timeout after 10"');
-        assert.equal(err.cause.code, 'UND_ERR_INFO');
+        // undici@8 reports HTTP/2 headers timeout as a standard HeadersTimeoutError
+        assert.equal(err.cause.name, 'HeadersTimeoutError');
+        assert.equal(err.cause.message, 'HTTP/2: "headers timeout after 10"');
+        assert.equal(err.cause.code, 'UND_ERR_HEADERS_TIMEOUT');
 
         assert.equal(err.res.status, -1);
         assert(err.res.rt > 10, `actual ${err.res.rt}`);

--- a/test/options.timeout.test.ts
+++ b/test/options.timeout.test.ts
@@ -94,27 +94,32 @@ describe('options.timeout.test.ts', () => {
     await once(server, 'listening');
 
     const url = `https://localhost:${(server.address() as AddressInfo).port}`;
-    await assert.rejects(
-      async () => {
-        await httpClient.request(url, {
-          timeout: 10,
-        });
-      },
-      (err: any) => {
-        // console.error(err);
-        assert.equal(err.name, 'HttpClientRequestTimeoutError');
-        assert.equal(err.message, 'Request timeout for 10 ms');
-        // undici@8 reports HTTP/2 headers timeout as a standard HeadersTimeoutError
-        assert.equal(err.cause.name, 'HeadersTimeoutError');
-        assert.equal(err.cause.message, 'HTTP/2: "headers timeout after 10"');
-        assert.equal(err.cause.code, 'UND_ERR_HEADERS_TIMEOUT');
+    try {
+      await assert.rejects(
+        async () => {
+          await httpClient.request(url, {
+            timeout: 10,
+          });
+        },
+        (err: any) => {
+          // console.error(err);
+          assert.equal(err.name, 'HttpClientRequestTimeoutError');
+          assert.equal(err.message, 'Request timeout for 10 ms');
+          // undici@8 reports HTTP/2 headers timeout as a standard HeadersTimeoutError
+          assert.equal(err.cause.name, 'HeadersTimeoutError');
+          assert.equal(err.cause.message, 'HTTP/2: "headers timeout after 10"');
+          assert.equal(err.cause.code, 'UND_ERR_HEADERS_TIMEOUT');
 
-        assert.equal(err.res.status, -1);
-        assert(err.res.rt > 10, `actual ${err.res.rt}`);
-        assert.equal(typeof err.res.rt, 'number');
-        return true;
-      },
-    );
+          assert.equal(err.res.status, -1);
+          assert(err.res.rt > 10, `actual ${err.res.rt}`);
+          assert.equal(typeof err.res.rt, 'number');
+          return true;
+        },
+      );
+    } finally {
+      await httpClient.getDispatcher().close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it('should BodyTimeout throw error', async () => {


### PR DESCRIPTION
Upgrade undici from v7 to v8.

## Breaking changes

- **Node.js >= 22.19.0 required** (was `>= 22.0.0`).
- **HTTP/2 is negotiated by default.** undici@8 flips `allowH2` to default `true`, so requests to HTTP/2-capable TLS servers now use HTTP/2 instead of HTTP/1.1. Pass `allowH2: false` (per request or per client) to force HTTP/1.1.
- **`allowH2: false` is applied per request** through the active dispatcher (default agent / `ProxyAgent`). It cannot downgrade a raw `Pool`/`Client` passed as `dispatcher` (construct those with `allowH2: false`), and is not applied under `MockAgent`.
- **HTTP/2 timeout error shape changed.** An HTTP/2 headers timeout now surfaces as `HeadersTimeoutError` / `UND_ERR_HEADERS_TIMEOUT` (was `InformationalError` / `UND_ERR_INFO`); code matching on `err.cause` must update.
- **`getDispatcherPoolStats()`** normalizes undici@8's `${origin}#http1-only` pool keys back to the origin, so a single origin entry may merge HTTP/2 and HTTP/1.1 pool stats.

## Other changes

- CI matrix tests Node 22, 24, 26.
- `Request.ts`: `signal` typed as `globalThis.AbortSignal` (v8 has a stricter `signal` type).

Closes #765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `allowH2` option for per-request HTTP/2 protocol negotiation control (HTTP/2 is enabled by default).
  * Improved handling of connection pool statistics to correctly combine HTTP/2 and HTTP/1.1 data for the same origin.
* **Dependencies**
  * Updated `undici` to `^8.4.1`.
  * Raised Node.js minimum version to `>= 22.19.0`.
* **Tests / CI**
  * Expanded protocol negotiation and pool/dispatcher tests; added Node.js 26 to the test matrix.
  * Added stricter Codecov patch coverage configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
