### PR TITLE
ci: hold Renovate PRs until packages pass sfw minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,7 @@
     },
     {
       "groupName": "vite-plus",
-      "matchPackageNames": [
-        "vite-plus",
-        "@voidzero-dev/vite-plus-core",
-        "@voidzero-dev/vite-plus-test",
-        "@vitest/coverage-v8"
-      ],
+      "matchPackageNames": ["vite-plus", "@voidzero-dev/*", "@vitest/*"],
       "minimumReleaseAge": "0 days"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,18 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "groupName": "vite-plus",
       "matchPackageNames": [
         "vite-plus",
         "@voidzero-dev/vite-plus-core",
         "@voidzero-dev/vite-plus-test",
         "@vitest/coverage-v8"
-      ]
+      ],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
## Problem

Renovate PRs fail at the **Setup Vite+** step because CI runs `sfw vp install` (Socket Firewall Free), which enforces pnpm's `minimumReleaseAge` cooldown. Renovate opens update PRs the moment a version is published, so the lockfile fails the supply-chain policy check:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification
```

Seen on the undici 8.4.1 -> 8.5.0 PR (#824).

## Fix

- `minimumReleaseAge: "3 days"` for all npm packages, so updates age past the sfw cooldown before a PR opens.
- `minimumReleaseAge: "0 days"` for the vite-plus group, which is already in `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` and can update immediately.

Values mirror voidzero's `Boshen/renovate` preset used with the same sfw setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to adjust how quickly new package releases are considered available (reduced minimum release age for certain rules and broadened matching patterns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->