### PR TITLE
ci: pin setup-vp action to latest main commit

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
         with:
           node-version: '24'
           cache: true
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
         with:
           node-version: ${{ matrix.node }}
           cache: true

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
         with:
           node-version: 22
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
         with:
           # Node 24 bundles npm >= 11.5.1, required for OIDC trusted publishing.
           node-version: '24'


### PR DESCRIPTION
Update `voidzero-dev/setup-vp` from the floating `@v1` tag to the pinned latest commit on `main` ([13e7afb](https://github.com/voidzero-dev/setup-vp/commit/13e7afb99c66525824db54e107d667216e795d37), feat: resolve Vite+ version from package.json / catalog / lockfile #102).

This matches the repo convention of SHA-pinning actions with a version comment. Applied across `nodejs.yml`, `release.yml`, and `pkg.pr.new.yml` (4 references).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use a fixed version of a third-party setup action for more consistent and reliable runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->