### PR TITLE
chore: add vitest to vite-plus renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     },
     {
       "groupName": "vite-plus",
-      "matchPackageNames": ["vite-plus", "@voidzero-dev/*", "@vitest/*"],
+      "matchPackageNames": ["vite-plus", "vitest", "@voidzero-dev/*", "@vitest/*"],
       "minimumReleaseAge": "0 days"
     }
   ]


### PR DESCRIPTION
Group `vitest` updates with the existing vite-plus renovate group so it upgrades together with `vite-plus` and `@vitest/*` without the 3-day minimum release age.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings so the configured minimum release age also applies to the Vitest package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->